### PR TITLE
Add measure_power capability for powernode-1 driver

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
 		"en": "Greenwave Systems",
 		"nl": "Greenwave Systems"
 	},
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"compatibility": ">=0.9.2",
 	"author": {
 		"name": "Athom B.V.",
@@ -48,6 +48,7 @@
 			"class": "socket",
 			"capabilities": [
 				"onoff",
+                "measure_power",
 				"meter_power"
 			],
 			"images": {
@@ -73,6 +74,7 @@
 						"class": "socket",
 						"capabilities": [
 							"onoff",
+                            "measure_power",
 							"meter_power"
 						],
 						"icon": "/drivers/powernode-1/assets/icon.svg",

--- a/drivers/powernode-1/driver.js
+++ b/drivers/powernode-1/driver.js
@@ -5,39 +5,66 @@ const ZwaveDriver	= require('homey-zwavedriver');
 
 // http://www.pepper1.net/zwavedb/device/280
 
-module.exports = new ZwaveDriver(path.basename(__dirname), {
+module.exports = new ZwaveDriver( path.basename(__dirname), {
 	debug: false,
 	capabilities: {
 		'onoff': {
 			'command_class'				: 'COMMAND_CLASS_SWITCH_BINARY',
-			'command_get'					: 'SWITCH_BINARY_GET',
+			'command_get'				: 'SWITCH_BINARY_GET',
 			'command_get_cb'			: false,
-			'command_set'					: 'SWITCH_BINARY_SET',
-			'command_set_parser'	: function(value) {
+			'command_set'				: 'SWITCH_BINARY_SET',
+			'command_set_parser'	    : function( value ) {
 				return {
 					'Switch Value': value
 				}
 			},
-			'command_report'				: 'SWITCH_BINARY_REPORT',
-			'command_report_parser'	: function(report) {
+			'command_report'		    : 'SWITCH_BINARY_REPORT',
+			'command_report_parser'	    : function(report) {
 				return report['Value'] === 'on/enable';
+			},
+			'pollInterval': "poll_interval"
+		},
+        'measure_power': {
+			'command_class'				: 'COMMAND_CLASS_METER',
+			'command_get'				: 'METER_GET',
+			'command_get_cb'			: false,
+			'command_get_parser'		: function(){
+				return {
+					'Properties1': {
+						'Scale': 2
+					}
+				}
+			},
+            'command_report'			: 'METER_REPORT',
+			'command_report_parser'		: function( report ) {
+                if (report && report.hasOwnProperty('Properties2')
+					&& report.Properties2.hasOwnProperty('Scale')
+					&& report.Properties2['Scale'] === 2) {
+
+					return report['Meter Value (Parsed)'];
+				} else return null;
 			},
 			'pollInterval': "poll_interval"
 		},
 		'meter_power': {
 			'command_class'				: 'COMMAND_CLASS_METER',
-			'command_get'					: 'METER_GET',
+			'command_get'				: 'METER_GET',
 			'command_get_cb'			: false,
-			'command_get_parser'	: function(power) {
+			'command_get_parser'	    : function() {
 				return {
 					'Properties1': {
 						'Scale': 0
 					}
 				}
 			},
-			'command_report'				: 'METER_REPORT',
-			'command_report_parser'	: function(report) {
-				return report['Meter Value (Parsed)'];
+			'command_report'		    : 'METER_REPORT',
+			'command_report_parser'	    : function( report ) {
+                if (report && report.hasOwnProperty('Properties2')
+					&& report.Properties2.hasOwnProperty('Scale')
+					&& report.Properties2['Scale'] === 0) {
+
+					return report['Meter Value (Parsed)'];
+				} else return null;
 			},
 			'pollInterval': "poll_interval"
 		}


### PR DESCRIPTION
**Add measure_power capability for powernode-1 driver.** 

When the pull request for the powernode-1 driver was created the measure power capability was not available for the powernode-6 which was used as example. But the pull request for measure_power for the powernode-6 got merged before merging the powernode-1 driver. And while merging the powernode-1 driver the measure_power capability was not added to the driver manually. This pull request fixes that and adds the measure_power capability also to the powernode-1 driver.

I'd suggest this gets merged and published to the app store asap as it will be confusing for users that powernode-6 devices do have this capability and powernode-1 devices dont with version 1.0.2. As it needs repairing of the devices to get the capability users may become frustrated that they will have to repair their powernode-1 devices with version 1.0.3 (this pull request) again to get the measure_power capability.

[EDIT]
One other thing, Ivo Derksen created proper svg icons for the powernode-1 but it seems the icons I have created myself have been merged into to app. Athom might wanna replace them with the ones made by Ivo as they will probably be better.