### PR TITLE
Remove parser from keep alive time parameter

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
 		"en": "Greenwave Systems",
 		"nl": "Greenwave Systems"
 	},
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"compatibility": ">=0.9.2",
 	"author": {
 		"name": "Athom B.V.",

--- a/drivers/powernode-1/driver.js
+++ b/drivers/powernode-1/driver.js
@@ -28,7 +28,7 @@ module.exports = new ZwaveDriver( path.basename(__dirname), {
 			'command_class'				: 'COMMAND_CLASS_METER',
 			'command_get'				: 'METER_GET',
 			'command_get_cb'			: false,
-			'command_get_parser'		: function(){
+			'command_get_parser'		: function() {
 				return {
 					'Properties1': {
 						'Scale': 2
@@ -72,10 +72,7 @@ module.exports = new ZwaveDriver( path.basename(__dirname), {
 	settings: {
 		"keep_alive_time": {
 			"index": 1,
-			"size": 1,
-			"parser": function( input ) {
-				return new Buffer([parseInt(input)]);
-			}
+			"size": 1
 		}
 	}
 });

--- a/drivers/powernode-6/driver.js
+++ b/drivers/powernode-6/driver.js
@@ -72,10 +72,7 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 	settings: {
 		"keep_alive_time": {
 			"index": 1,
-			"size": 1,
-			"parser": function (input) {
-				return new Buffer([parseInt(input)]);
-			}
+			"size": 1
 		}
 	}
 });


### PR DESCRIPTION
Both Powernode 1 and Powernode 6 drivers have a setting parameter called keep alive time. Currently the value of this setting is parsed upon saving it but this is not needed as it's a just simple numeric value.

So this is just a simple refactoring pull request to keep it clean and wont affect the functionality.