### PR TITLE
Update to include add. parameters + default config

### DIFF
--- a/app.json
+++ b/app.json
@@ -76,18 +76,51 @@
 				],
 				"defaultConfiguration": [
 					{
-						"id": "keep_alive_time",
+						"id": 0, // power_change_percentage
+						"size": 1,
+						"value": 80
+					},
+					{
+						"id": 1, // keep_alive_time
 						"size": 1,
 						"value": 255
-					}
+					},
+					{
+						"id": 3, // State_power_loss
+						"size": 1,
+						"value": 2
+					},
+					{
+						"id": 4, // LED_network
+						"size": true,
+						"value": 255
+					},
+					
 				]
 			},
 			"settings": [
-				{
+					{
+					"id": "power_change_percentage",
+					"type": "number",
+					"attr": {
+						"min": 1,
+						"max": 100
+					},
+					"value": 80,
+					"label": {
+						"en": "Power change for update",
+						"nl": "Wijziging in energie voor update"
+					},
+					"hint": {
+						"en": "Power change required to send an update to controller, in % from 1 to 100.",
+						"nl": "Wijziging in energie voordat er een update naar de controller wordt gestuurd, in % van 1 tot 100."
+					}
+					},
+					{
 					"id": "poll_interval",
 					"type": "number",
 					"attr": {
-						"min": 60,
+						"min": 0,
 						"max": 3600
 					},
 					"value": 300,
@@ -126,8 +159,8 @@
 					},
 					"value": "2",
 					"hint": {
-						"en": "State after power loss, 0 = all off, 1 = remember last state, 2 = all on, default: all on",
-						"nl": "Toestand na stroom uitval, 0 = allemaal uit, 1 = herinner laatste toestand, 2 = allemaal aan, standaard: allemaal aan"
+						"en": "State after power loss, 0 = ALL OFF, 1 = remember last state, 2 = ALL ON, default: all on",
+						"nl": "Toestand na stroom uitval, 0 = ALLEN UIT, 1 = herinner laatste toestand, 2 = ALLEN AAN, standaard: allemaal aan"
 					},
 					"values": [
 						{
@@ -162,7 +195,7 @@
 					},
 					"value": true,
 					"hint": {
-						"en": "Led for network error, checked = enabled, unchecked = disable, default enabled",
+						"en": "Led for network error, checked = LED starts blinking with Z-wave network errors, unchecked = LED disabled, default: enabled",
 						"nl": "Led indicatie voor netwerk fouten, aangevinkt = Led knippert bij Z-wave netwerk fouten, niet aangevinkt = Led uitgeschakeld, standaard: ingeschakeld"
 					}
 				}
@@ -206,10 +239,25 @@
 				],
 				"defaultConfiguration": [
 					{
-						"id": "keep_alive_time",
+						"id": 0, // power_change_percentage
+						"size": 1,
+						"value": 80
+					},
+					{
+						"id": 1, // keep_alive_time
 						"size": 1,
 						"value": 255
-					}
+					},
+					{
+						"id": 3, // State_power_loss
+						"size": 1,
+						"value": 2
+					},
+					{
+						"id": 4, // LED_network
+						"size": true,
+						"value": 255
+					},
 				],
 				"multiChannelNodes": {
 					"1": {
@@ -288,6 +336,23 @@
 			},
 			"settings": [
 				{
+					"id": "power_change_percentage",
+					"type": "number",
+					"attr": {
+						"min": 1,
+						"max": 100
+					},
+					"value": 80,
+					"label": {
+						"en": "Power change for update",
+						"nl": "Wijziging in energie voor update"
+					},
+					"hint": {
+						"en": "Power change required to send an update to controller, in % from 1 to 100.",
+						"nl": "Wijziging in energie voordat er een update naar de controller wordt gestuurd, in % van 1 tot 100."
+					}
+					},
+					{
 					"id": "poll_interval",
 					"type": "number",
 					"attr": {
@@ -330,8 +395,8 @@
 					},
 					"value": "2",
 					"hint": {
-						"en": "State after power loss, 0 = all off, 1 = remember last state, 2 = all on, default: all on",
-						"nl": "Toestand na stroom uitval, 0 = allemaal uit, 1 = herinner laatste toestand, 2 = allemaal aan, standaard: allemaal aan"
+						"en": "State after power loss, 0 = ALL OFF, 1 = remember last state, 2 = ALL ON, default: all on",
+						"nl": "Toestand na stroom uitval, 0 = ALLEN UIT, 1 = herinner laatste toestand, 2 = ALLEN AAN, standaard: allemaal aan"
 					},
 					"values": [
 						{
@@ -366,7 +431,7 @@
 					},
 					"value": true,
 					"hint": {
-						"en": "Led for network error, checked = enabled, unchecked = disable, default enabled",
+						"en": "Led for network error, checked = LED starts blinking with Z-wave network errors, unchecked = LED disabled, default: enabled",
 						"nl": "Led indicatie voor netwerk fouten, aangevinkt = Led knippert bij Z-wave netwerk fouten, niet aangevinkt = Led uitgeschakeld, standaard: ingeschakeld"
 					}
 				}

--- a/app.json
+++ b/app.json
@@ -76,26 +76,25 @@
 				],
 				"defaultConfiguration": [
 					{
-						"id": 0,
+						"id": "power_change_percentage",
 						"size": 1,
 						"value": 80
 					},
 					{
-						"id": 1,
+						"id": "keep_alive_time",
 						"size": 1,
 						"value": 255
 					},
 					{
-						"id": 3,
+						"id": "State_power_loss",
 						"size": 1,
 						"value": 2
 					},
 					{
-						"id": 4,
+						"id": "LED_network",
 						"size": 1,
-						"value": true
-					}
-					
+						"value": 1
+					}	
 				]
 			},
 			"settings": [
@@ -239,25 +238,25 @@
 				],
 				"defaultConfiguration": [
 					{
-						"id": 0,
+						"id": "power_change_percentage",
 						"size": 1,
 						"value": 80
 					},
 					{
-						"id": 1,
+						"id": "keep_alive_time",
 						"size": 1,
 						"value": 255
 					},
 					{
-						"id": 3,
+						"id": "State_power_loss",
 						"size": 1,
 						"value": 2
 					},
 					{
-						"id": 4,
+						"id": "LED_network",
 						"size": 1,
-						"value": true
-					}
+						"value": 1
+					}	
 				],
 				"multiChannelNodes": {
 					"1": {

--- a/app.json
+++ b/app.json
@@ -76,25 +76,15 @@
 				],
 				"defaultConfiguration": [
 					{
-						"id": "power_change_percentage",
+						"id": 0,
 						"size": 1,
 						"value": 80
 					},
 					{
-						"id": "keep_alive_time",
+						"id": 1,
 						"size": 1,
-						"value": 255
-					},
-					{
-						"id": "State_power_loss",
-						"size": 1,
-						"value": 2
-					},
-					{
-						"id": "LED_network",
-						"size": 1,
-						"value": 1
-					}	
+						"value": 120
+					}
 				]
 			},
 			"settings": [
@@ -111,8 +101,8 @@
 						"nl": "Wijziging in energie voor update"
 					},
 					"hint": {
-						"en": "Power change required to send an update to controller, in % from 1 to 100.",
-						"nl": "Wijziging in energie voordat er een update naar de controller wordt gestuurd, in % van 1 tot 100."
+						"en": "Power change required to send an update to controller, in % from 1 to 100, default: 80 [%].",
+						"nl": "Wijziging in energie voordat er een update naar de controller wordt gestuurd, in % van 1 tot 100, standaard: 80 [%].."
 					}
 					},
 					{
@@ -124,12 +114,12 @@
 					},
 					"value": 300,
 					"label": {
-						"en": "Polling Interval",
-						"nl": "Polling Interval"
+						"en": "Poll Interval",
+						"nl": "Poll Interval"
 					},
 					"hint": {
-						"en": "The amount of seconds between asking the device for a status update.",
-						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat."
+						"en": "The amount of seconds between asking the device for a status update, default: 300 [s].",
+						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, standaard: 300 [s]."
 					}
 				},
 				{
@@ -139,63 +129,14 @@
 						"min": 1,
 						"max": 255
 					},
-					"value": 255,
+					"value": 120,
 					"label": {
 						"en": "Keep Alive Time",
-						"nl": "Keep Alive Time "
+						"nl": "Keep Alive Time"
 					},
 					"hint": {
-						"en": "The amount of minutes without contact between controller and device before the device starts blinking green.",
-						"nl": "Aantal minuten zonder contact tussen controller en apparaat voordat het apparaat groen gaat knipperen."
-					}
-				},
-				{
-					"id": "State_power_loss",
-					"type": "dropdown",
-					"label": {
-						"en": "State after power loss",
-						"nl": "Toestand na stroomuitval"
-					},
-					"value": "2",
-					"hint": {
-						"en": "State after power loss, 0 = ALL OFF, 1 = remember last state, 2 = ALL ON, default: all on",
-						"nl": "Toestand na stroom uitval, 0 = ALLEN UIT, 1 = herinner laatste toestand, 2 = ALLEN AAN, standaard: allemaal aan"
-					},
-					"values": [
-						{
-							"id": "0",
-							"label": {
-								"en": "All OFF",
-								"nl": "Allemaal UIT"
-							}
-						},
-						{
-							"id": "1",
-							"label": {
-								"en": "Remember last state",
-								"nl": "Herinner laatste toestand"
-							}
-						},
-						{
-							"id": "2",
-							"label": {
-								"en": "All ON (default)",
-								"nl": "Allemaal AAN (standaard)"
-							}
-						}
-					]
-				},
-				{
-					"id": "LED_network",
-					"type": "checkbox",
-					"label": {
-						"en": "LED network status",
-						"nl": "LED network status"
-					},
-					"value": true,
-					"hint": {
-						"en": "Led for network error, checked = LED starts blinking with Z-wave network errors, unchecked = LED disabled, default: enabled",
-						"nl": "Led indicatie voor netwerk fouten, aangevinkt = Led knippert bij Z-wave netwerk fouten, niet aangevinkt = Led uitgeschakeld, standaard: ingeschakeld"
+						"en": "The amount of minutes without contact between controller and device before the device starts blinking green, default: 255 [min].",
+						"nl": "Aantal minuten zonder contact tussen controller en apparaat voordat het apparaat groen gaat knipperen, standaard: 255 [min]."
 					}
 				}
 			]
@@ -238,25 +179,15 @@
 				],
 				"defaultConfiguration": [
 					{
-						"id": "power_change_percentage",
+						"id": 0,
 						"size": 1,
 						"value": 80
 					},
 					{
-						"id": "keep_alive_time",
+						"id": 1,
 						"size": 1,
-						"value": 255
-					},
-					{
-						"id": "State_power_loss",
-						"size": 1,
-						"value": 2
-					},
-					{
-						"id": "LED_network",
-						"size": 1,
-						"value": 1
-					}	
+						"value": 120
+					}
 				],
 				"multiChannelNodes": {
 					"1": {
@@ -334,7 +265,7 @@
 				}
 			},
 			"settings": [
-				{
+					{
 					"id": "power_change_percentage",
 					"type": "number",
 					"attr": {
@@ -347,8 +278,8 @@
 						"nl": "Wijziging in energie voor update"
 					},
 					"hint": {
-						"en": "Power change required to send an update to controller, in % from 1 to 100.",
-						"nl": "Wijziging in energie voordat er een update naar de controller wordt gestuurd, in % van 1 tot 100."
+						"en": "Power change required to send an update to controller, in % from 1 to 100, default: 80 [%].",
+						"nl": "Wijziging in energie voordat er een update naar de controller wordt gestuurd, in % van 1 tot 100, standaard: 80 [%].."
 					}
 					},
 					{
@@ -364,8 +295,8 @@
 						"nl": "Poll Interval"
 					},
 					"hint": {
-						"en": "The amount of seconds between asking the device for a status update.",
-						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat."
+						"en": "The amount of seconds between asking the device for a status update, default: 300 [s].",
+						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, standaard: 300 [s]."
 					}
 				},
 				{
@@ -375,63 +306,14 @@
 						"min": 1,
 						"max": 255
 					},
-					"value": 255,
+					"value": 120,
 					"label": {
 						"en": "Keep Alive Time",
 						"nl": "Keep Alive Time"
 					},
 					"hint": {
-						"en": "The amount of minutes without contact between controller and device before the device starts blinking green.",
-						"nl": "Aantal minuten zonder contact tussen controller en apparaat voordat het apparaat groen gaat knipperen."
-					}
-				},
-				{
-					"id": "State_power_loss",
-					"type": "dropdown",
-					"label": {
-						"en": "State after power loss",
-						"nl": "Toestand na stroomuitval"
-					},
-					"value": "2",
-					"hint": {
-						"en": "State after power loss, 0 = ALL OFF, 1 = remember last state, 2 = ALL ON, default: all on",
-						"nl": "Toestand na stroom uitval, 0 = ALLEN UIT, 1 = herinner laatste toestand, 2 = ALLEN AAN, standaard: allemaal aan"
-					},
-					"values": [
-						{
-							"id": "0",
-							"label": {
-								"en": "All OFF",
-								"nl": "Allemaal UIT"
-							}
-						},
-						{
-							"id": "1",
-							"label": {
-								"en": "Remember last state",
-								"nl": "Herinner laatste toestand"
-							}
-						},
-						{
-							"id": "2",
-							"label": {
-								"en": "All ON (default)",
-								"nl": "Allemaal AAN (standaard)"
-							}
-						}
-					]
-				},
-				{
-					"id": "LED_network",
-					"type": "checkbox",
-					"label": {
-						"en": "LED network status",
-						"nl": "LED network status"
-					},
-					"value": true,
-					"hint": {
-						"en": "Led for network error, checked = LED starts blinking with Z-wave network errors, unchecked = LED disabled, default: enabled",
-						"nl": "Led indicatie voor netwerk fouten, aangevinkt = Led knippert bij Z-wave netwerk fouten, niet aangevinkt = Led uitgeschakeld, standaard: ingeschakeld"
+						"en": "The amount of minutes without contact between controller and device before the device starts blinking green, default: 255 [min].",
+						"nl": "Aantal minuten zonder contact tussen controller en apparaat voordat het apparaat groen gaat knipperen, standaard: 255 [min]."
 					}
 				}
 			]

--- a/app.json
+++ b/app.json
@@ -19,6 +19,10 @@
 			{
 				"name": "Jelger Haanstra",
 				"email": "homey@solidewebservices.com"
+			},
+			{
+				"name": "Ted Tolboom",
+				"email": "dTNL.Homey@gmail.com"
 			}
 		]
 	},
@@ -111,6 +115,55 @@
 					"hint": {
 						"en": "The amount of minutes without contact between controller and device before the device starts blinking green.",
 						"nl": "Aantal minuten zonder contact tussen controller en apparaat voordat het apparaat groen gaat knipperen."
+					}
+				},
+				{
+					"id": "State_power_loss",
+					"type": "dropdown",
+					"label": {
+						"en": "State after power loss",
+						"nl": "Toestand na stroomuitval"
+					},
+					"value": "2",
+					"hint": {
+						"en": "State after power loss, 0 = all off, 1 = remember last state, 2 = all on, default: all on",
+						"nl": "Toestand na stroom uitval, 0 = allemaal uit, 1 = herinner laatste toestand, 2 = allemaal aan, standaard: allemaal aan"
+					},
+					"values": [
+						{
+							"id": "0",
+							"label": {
+								"en": "All OFF",
+								"nl": "Allemaal UIT"
+							}
+						},
+						{
+							"id": "1",
+							"label": {
+								"en": "Remember last state",
+								"nl": "Herinner laatste toestand"
+							}
+						},
+						{
+							"id": "2",
+							"label": {
+								"en": "All ON (default)",
+								"nl": "Allemaal AAN (standaard)"
+							}
+						}
+					]
+				},
+				{
+					"id": "LED_network",
+					"type": "checkbox",
+					"label": {
+						"en": "LED network status",
+						"nl": "LED network status"
+					},
+					"value": true,
+					"hint": {
+						"en": "Led for network error, checked = enabled, unchecked = disable, default enabled",
+						"nl": "Led indicatie voor netwerk fouten, aangevinkt = Led knippert bij Z-wave netwerk fouten, niet aangevinkt = Led uitgeschakeld, standaard: ingeschakeld"
 					}
 				}
 			]
@@ -266,6 +319,55 @@
 					"hint": {
 						"en": "The amount of minutes without contact between controller and device before the device starts blinking green.",
 						"nl": "Aantal minuten zonder contact tussen controller en apparaat voordat het apparaat groen gaat knipperen."
+					}
+				},
+				{
+					"id": "State_power_loss",
+					"type": "dropdown",
+					"label": {
+						"en": "State after power loss",
+						"nl": "Toestand na stroomuitval"
+					},
+					"value": "2",
+					"hint": {
+						"en": "State after power loss, 0 = all off, 1 = remember last state, 2 = all on, default: all on",
+						"nl": "Toestand na stroom uitval, 0 = allemaal uit, 1 = herinner laatste toestand, 2 = allemaal aan, standaard: allemaal aan"
+					},
+					"values": [
+						{
+							"id": "0",
+							"label": {
+								"en": "All OFF",
+								"nl": "Allemaal UIT"
+							}
+						},
+						{
+							"id": "1",
+							"label": {
+								"en": "Remember last state",
+								"nl": "Herinner laatste toestand"
+							}
+						},
+						{
+							"id": "2",
+							"label": {
+								"en": "All ON (default)",
+								"nl": "Allemaal AAN (standaard)"
+							}
+						}
+					]
+				},
+				{
+					"id": "LED_network",
+					"type": "checkbox",
+					"label": {
+						"en": "LED network status",
+						"nl": "LED network status"
+					},
+					"value": true,
+					"hint": {
+						"en": "Led for network error, checked = enabled, unchecked = disable, default enabled",
+						"nl": "Led indicatie voor netwerk fouten, aangevinkt = Led knippert bij Z-wave netwerk fouten, niet aangevinkt = Led uitgeschakeld, standaard: ingeschakeld"
 					}
 				}
 			]

--- a/app.json
+++ b/app.json
@@ -125,8 +125,8 @@
 					},
 					"value": 300,
 					"label": {
-						"en": "Poll Interval",
-						"nl": "Poll Interval"
+						"en": "Polling Interval",
+						"nl": "Polling Interval"
 					},
 					"hint": {
 						"en": "The amount of seconds between asking the device for a status update.",
@@ -143,7 +143,7 @@
 					"value": 255,
 					"label": {
 						"en": "Keep Alive Time",
-						"nl": "Keep Alive Time"
+						"nl": "Keep Alive Time "
 					},
 					"hint": {
 						"en": "The amount of minutes without contact between controller and device before the device starts blinking green.",

--- a/app.json
+++ b/app.json
@@ -76,22 +76,22 @@
 				],
 				"defaultConfiguration": [
 					{
-						"id": 0, // power_change_percentage
+						"id": 0,
 						"size": 1,
 						"value": 80
 					},
 					{
-						"id": 1, // keep_alive_time
+						"id": 1,
 						"size": 1,
 						"value": 255
 					},
 					{
-						"id": 3, // State_power_loss
+						"id": 3,
 						"size": 1,
 						"value": 2
 					},
 					{
-						"id": 4, // LED_network
+						"id": 4,
 						"size": 1,
 						"value": true
 					},
@@ -239,22 +239,22 @@
 				],
 				"defaultConfiguration": [
 					{
-						"id": 0, // power_change_percentage
+						"id": 0,
 						"size": 1,
 						"value": 80
 					},
 					{
-						"id": 1, // keep_alive_time
+						"id": 1,
 						"size": 1,
 						"value": 255
 					},
 					{
-						"id": 3, // State_power_loss
+						"id": 3,
 						"size": 1,
 						"value": 2
 					},
 					{
-						"id": 4, // LED_network
+						"id": 4,
 						"size": 1,
 						"value": true
 					},

--- a/app.json
+++ b/app.json
@@ -92,8 +92,8 @@
 					},
 					{
 						"id": 4, // LED_network
-						"size": true,
-						"value": 255
+						"size": 1,
+						"value": true
 					},
 					
 				]
@@ -255,8 +255,8 @@
 					},
 					{
 						"id": 4, // LED_network
-						"size": true,
-						"value": 255
+						"size": 1,
+						"value": true
 					},
 				],
 				"multiChannelNodes": {

--- a/app.json
+++ b/app.json
@@ -94,7 +94,7 @@
 						"id": 4,
 						"size": 1,
 						"value": true
-					},
+					}
 					
 				]
 			},
@@ -257,7 +257,7 @@
 						"id": 4,
 						"size": 1,
 						"value": true
-					},
+					}
 				],
 				"multiChannelNodes": {
 					"1": {

--- a/drivers/powernode-1/driver.js
+++ b/drivers/powernode-1/driver.js
@@ -78,6 +78,20 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 				newValue.writeUIntBE(Number(input), 0, 1);
 				return newValue;
 			}
+		},
+		"State_power_loss": {
+			"index": 3,
+			"size": 1,
+			"parser": input => {
+				const newValue = new Buffer(1);
+				newValue.writeUIntBE(Number(input), 0, 1);
+				return newValue;
+			}
+		},
+		"LED_network": {
+			"index": 4,
+			"size": 1,
+			"parser": value => new Buffer([ (value === true) ? 1 : 0 ])
 		}
 	}
 });

--- a/drivers/powernode-1/driver.js
+++ b/drivers/powernode-1/driver.js
@@ -70,6 +70,10 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 		}
 	},
 	settings: {
+		"power_change_percentage": {
+			"index": 0,
+			"size": 1,
+		},
 		"keep_alive_time": {
 			"index": 1,
 			"size": 1,

--- a/drivers/powernode-6/driver.js
+++ b/drivers/powernode-6/driver.js
@@ -6,6 +6,7 @@ const ZwaveDriver = require('homey-zwavedriver');
 // http://www.pepper1.net/zwavedb/device/280
 
 module.exports = new ZwaveDriver(path.basename(__dirname), {
+	debug: true,
 	capabilities: {
 		'onoff': {
 			'command_class': 'COMMAND_CLASS_SWITCH_BINARY',

--- a/drivers/powernode-6/driver.js
+++ b/drivers/powernode-6/driver.js
@@ -78,6 +78,20 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 				newValue.writeUIntBE(Number(input), 0, 1);
 				return newValue;
 			}
+		},
+		"State_power_loss": {
+			"index": 3,
+			"size": 1,
+			"parser": input => {
+				const newValue = new Buffer(1);
+				newValue.writeUIntBE(Number(input), 0, 1);
+				return newValue;
+			}
+		},
+		"LED_network": {
+			"index": 4,
+			"size": 1,
+			"parser": value => new Buffer([ (value === true) ? 1 : 0 ])
 		}
 	}
 });

--- a/drivers/powernode-6/driver.js
+++ b/drivers/powernode-6/driver.js
@@ -70,6 +70,10 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 		}
 	},
 	settings: {
+		"power_change_percentage": {
+			"index": 0,
+			"size": 1,
+		},
 		"keep_alive_time": {
 			"index": 1,
 			"size": 1,


### PR DESCRIPTION
Added Defaultconfig (not working based on string ID's, reverted to integer ID's)
- Max keep-alive time value is 120. With values higher than 150 in default config, the pairing wizard will not continue - will create issue for this
- Adapted settings value to 120; otherwise if someone will change it to 255 it will not be changed (no successfull comparison)
- Added powerchange setting and set to 80 % (overtaking #21, which will become obsolete)

- Added LED network status and State power loss to the drivers for PN1 and PN6. Did not add them to app.json, since this setting will only have effect on powernodes with FW v2.48 or higher... will test further with my powernodes and file separate PR
- Added debug variable in powernode-6 driver.js
- Enabled setting polling of PN-1 to 0 (was minimum of 60)