### PR TITLE
Update of DefaultConfig and AssociationGroup hints inline with Homey SW 1.0.5

### DIFF
--- a/app.json
+++ b/app.json
@@ -83,8 +83,8 @@
 					},
 				"2": {
 					"hint": {
-						"en": "Reports alarm report when detecting current leakage and powers off relay if an association relationship exists. (not implemented yet)",
-						"nl": "Rapportage van een alarm op het moment dat een lekstroom gedetecteerd wordt op een relay. (niet geïmplementeerd)"
+						"en": "Reports alarm report when detecting current leakage of defined relay device if an association relationship has been defined (add Z-wave ID of relay device).",
+						"nl": "Rapportage van een alarm op het moment dat een lekstroom gedetecteerd wordt op een gekoppelds apparaat indien een relatie gedefineerd is (voeg het Z-wave ID van het te koppelen apparaat toe)."
 						}
 					},
 				"3": {
@@ -95,8 +95,8 @@
 					},
 				"4": {
 					"hint": {
-						"en": "Reports alarm when the powernode is in over-current protection (not implemented yet)",
-						"nl": "Alarm reportage wanneer de powernode in over-current protectie overschakeld (niet geïmplementeerd)"
+						"en": "Reports alarm when the powernode is in over-current protection and powers off a relay device if an association relationship has been defined (add Z-wave ID of relay device).",
+						"nl": "Alarm reportage wanneer de powernode in over-current protectie overschakeld en automatische uitschakeling van het gekoppelde apparaat indien een relatie gedefineerd is (voeg het Z-wave ID van het te koppelen apparaat toe)."
 						}
 					}
 				},
@@ -212,8 +212,8 @@
 					},
 				"2": {
 					"hint": {
-						"en": "Reports alarm report when detecting current leakage and powers off relay if an association relationship exists. (not implemented yet)",
-						"nl": "Rapportage van een alarm op het moment dat een lekstroom gedetecteerd wordt op een relay. (niet geïmplementeerd)"
+						"en": "Reports alarm report when detecting current leakage of defined relay device if an association relationship has been defined (add Z-wave ID of relay device).",
+						"nl": "Rapportage van een alarm op het moment dat een lekstroom gedetecteerd wordt op een gekoppelds apparaat indien een relatie gedefineerd is (voeg het Z-wave ID van het te koppelen apparaat toe)."
 						}
 					},
 				"3": {
@@ -224,8 +224,8 @@
 					},
 				"4": {
 					"hint": {
-						"en": "Reports alarm when the powernode is in over-current protection (not implemented yet)",
-						"nl": "Alarm reportage wanneer de powernode in over-current protectie overschakeld (niet geïmplementeerd)"
+						"en": "Reports alarm when the powernode is in over-current protection and powers off a relay device if an association relationship has been defined (add Z-wave ID of relay device).",
+						"nl": "Alarm reportage wanneer de powernode in over-current protectie overschakeld en automatische uitschakeling van het gekoppelde apparaat indien een relatie gedefineerd is (voeg het Z-wave ID van het te koppelen apparaat toe)."
 						}
 					}
 				},

--- a/app.json
+++ b/app.json
@@ -78,7 +78,7 @@
 				"1": {
 					"hint": {
 						"en": "Reports the device status and allows control (ON/OFF) over the powernode (Homey's ID by default). It is not recommended to change this group.",
-						"nl": "Rapportage van de status van de powernode en staat controle (AAN/UIT) over de powernode toe (Homey's ID als standaard waarde). Het is niet aanbevolen om deze group aan te passen."
+						"nl": "Rapportage van de status van de powernode en staat controle (AAN/UIT) over de powernode toe (Homey's ID als standaard waarde). Het is niet aanbevolen om deze groep aan te passen."
 						}
 					},
 				"2": {
@@ -90,7 +90,7 @@
 				"3": {
 					"hint": {
 						"en": "Reports the power value change if the difference of the instant power reading compared to previous report is larger than the 'Power change for update' parameter set (e.g. 80%). (Homey's ID by default)",
-						"nl": "Rapportage van de gebruikte energie wanneer het verschil met de vorige rapportage groter is dan de waarde ingesteld bij 'Wijziging in energie voor update' (bv. 80%). (Homey's ID als standaard waarde)"
+						"nl": "Rapportage van de gebruikte energie wanneer het verschil met de vorige rapportage groter is dan de waarde ingesteld bij 'Wijziging in energie voor update' parameter (bv. 80%). (Homey's ID als standaard waarde)"
 						}
 					},
 				"4": {
@@ -207,7 +207,7 @@
 				"1": {
 					"hint": {
 						"en": "Reports the device status and allows control (ON/OFF) over the powernode (Homey's ID by default). It is not recommended to change this group.",
-						"nl": "Rapportage van de status van de powernode en staat controle (AAN/UIT) over de powernode toe (Homey's ID als standaard waarde). Het is niet aanbevolen om deze group aan te passen."
+						"nl": "Rapportage van de status van de powernode en staat controle (AAN/UIT) over de powernode toe (Homey's ID als standaard waarde). Het is niet aanbevolen om deze groep aan te passen."
 						}
 					},
 				"2": {
@@ -219,7 +219,7 @@
 				"3": {
 					"hint": {
 						"en": "Reports the power value change if the difference of the instant power reading compared to previous report is larger than the 'Power change for update' parameter set (e.g. 80%). (Homey's ID by default)",
-						"nl": "Rapportage van de gebruikte energie wanneer het verschil met de vorige rapportage groter is dan de waarde ingesteld bij 'Wijziging in energie voor update' (bv. 80%). (Homey's ID als standaard waarde)"
+						"nl": "Rapportage van de gebruikte energie wanneer het verschil met de vorige rapportage groter is dan de waarde ingesteld bij 'Wijziging in energie voor update' parameter (bv. 80%). (Homey's ID als standaard waarde)"
 						}
 					},
 				"4": {

--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
 		"nl": "Greenwave Systems"
 	},
 	"version": "1.0.9",
-	"compatibility": ">=1.0.5",
+	"compatibility": ">=0.9.2",
 	"author": {
 		"name": "Athom B.V.",
 		"email": "info@athom.com"
@@ -74,6 +74,32 @@
 					1,
 					3
 				],
+				"associationGroupsOptions": {
+				"1": {
+					"hint": {
+						"en": "Reports the device status and allows control (ON/OFF) over the powernode (Homey's ID by default). It is not recommended to change this group.",
+						"nl": "Rapportage van de status van de powernode en staat controle (AAN/UIT) over de powernode toe (Homey's ID als standaard waarde). Het is niet aanbevolen om deze group aan te passen."
+						}
+					},
+				"2": {
+					"hint": {
+						"en": "Reports alarm report when detecting current leakage and powers off relay if an association relationship exists. (not implemented yet)",
+						"nl": "Rapportage van een alarm op het moment dat een lekstroom gedetecteerd wordt op een relay. (niet geïmplementeerd)"
+						}
+					},
+				"3": {
+					"hint": {
+						"en": "Reports the power value change if the difference of the instant power reading compared to previous report is larger than the 'Power change for update' parameter set (e.g. 80%). (Homey's ID by default)",
+						"nl": "Rapportage van de gebruikte energie wanneer het verschil met de vorige rapportage groter is dan de waarde ingesteld bij 'Wijziging in energie voor update' (bv. 80%). (Homey's ID als standaard waarde)"
+						}
+					},
+				"4": {
+					"hint": {
+						"en": "Reports alarm when the powernode is in over-current protection (not implemented yet)",
+						"nl": "Alarm reportage wanneer de powernode in over-current protectie overschakeld (niet geïmplementeerd)"
+						}
+					}
+				},
 				"defaultConfiguration": [
 					{
 						"id": 0,
@@ -180,14 +206,14 @@
 				"associationGroupsOptions": {
 				"1": {
 					"hint": {
-						"en": "Reports the device status and allows control over the powernode (Homey's ID by default). It is not recommended to change this group.",
-						"nl": "Rapportage van de status van de powernode en staat controle over de powernode toe (Homey's ID als standaard waarde). Het is niet aanbevolen om deze group aan te passen."
+						"en": "Reports the device status and allows control (ON/OFF) over the powernode (Homey's ID by default). It is not recommended to change this group.",
+						"nl": "Rapportage van de status van de powernode en staat controle (AAN/UIT) over de powernode toe (Homey's ID als standaard waarde). Het is niet aanbevolen om deze group aan te passen."
 						}
 					},
 				"2": {
 					"hint": {
-						"en": "Reports alarm report when detecting current leakage on relay if an association relationship exists. (not in use)",
-						"nl": "Rapportage van een alarm op het moment dat een lekstroom gedetecteerd wordt op een relay. (niet in gebruik)"
+						"en": "Reports alarm report when detecting current leakage and powers off relay if an association relationship exists. (not implemented yet)",
+						"nl": "Rapportage van een alarm op het moment dat een lekstroom gedetecteerd wordt op een relay. (niet geïmplementeerd)"
 						}
 					},
 				"3": {
@@ -198,8 +224,8 @@
 					},
 				"4": {
 					"hint": {
-						"en": "Reports alarm when the powernode is in over-current protection (not in use)",
-						"nl": "Alarm reportage wanneer de powernode in over-current protectie overschakeld (niet in gebruik)",
+						"en": "Reports alarm when the powernode is in over-current protection (not implemented yet)",
+						"nl": "Alarm reportage wanneer de powernode in over-current protectie overschakeld (niet geïmplementeerd)"
 						}
 					}
 				},

--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
 		"nl": "Greenwave Systems"
 	},
 	"version": "1.0.9",
-	"compatibility": ">=0.9.2",
+	"compatibility": ">=1.0.5",
 	"author": {
 		"name": "Athom B.V.",
 		"email": "info@athom.com"
@@ -83,7 +83,7 @@
 					{
 						"id": 1,
 						"size": 1,
-						"value": 120
+						"value": 255
 					}
 				]
 			},
@@ -112,7 +112,7 @@
 						"min": 1,
 						"max": 255
 					},
-					"value": 120,
+					"value": 255,
 					"label": {
 						"en": "Keep Alive Time",
 						"nl": "Keep Alive Time"
@@ -177,6 +177,32 @@
 					1,
 					3
 				],
+				"associationGroupsOptions": {
+				"1": {
+					"hint": {
+						"en": "Reports the device status and allows control over the powernode (Homey's ID by default). It is not recommended to change this group.",
+						"nl": "Rapportage van de status van de powernode en staat controle over de powernode toe (Homey's ID als standaard waarde). Het is niet aanbevolen om deze group aan te passen."
+						}
+					},
+				"2": {
+					"hint": {
+						"en": "Reports alarm report when detecting current leakage on relay if an association relationship exists. (not in use)",
+						"nl": "Rapportage van een alarm op het moment dat een lekstroom gedetecteerd wordt op een relay. (niet in gebruik)"
+						}
+					},
+				"3": {
+					"hint": {
+						"en": "Reports the power value change if the difference of the instant power reading compared to previous report is larger than the 'Power change for update' parameter set (e.g. 80%). (Homey's ID by default)",
+						"nl": "Rapportage van de gebruikte energie wanneer het verschil met de vorige rapportage groter is dan de waarde ingesteld bij 'Wijziging in energie voor update' (bv. 80%). (Homey's ID als standaard waarde)"
+						}
+					},
+				"4": {
+					"hint": {
+						"en": "Reports alarm when the powernode is in over-current protection (not in use)",
+						"nl": "Alarm reportage wanneer de powernode in over-current protectie overschakeld (niet in gebruik)",
+						}
+					}
+				},
 				"defaultConfiguration": [
 					{
 						"id": 0,
@@ -186,7 +212,7 @@
 					{
 						"id": 1,
 						"size": 1,
-						"value": 120
+						"value": 255
 					}
 				],
 				"multiChannelNodes": {
@@ -289,7 +315,7 @@
 						"min": 1,
 						"max": 255
 					},
-					"value": 120,
+					"value": 255,
 					"label": {
 						"en": "Keep Alive Time",
 						"nl": "Keep Alive Time"


### PR DESCRIPTION
1) Updated DefaultConfiguration to default values (Keep alive to 255) based on Homey SW 1.0.5 update (Added support for Z-Wave hexadecimal defaultConfiguration values). 
2) Added the association group hints based on Homey SW 1.0.5 (Added support for Z-Wave association group hints).
- question: have group 2 and 4 been fully implemented in the app; difficult to test due to over current trigger? or do we need to add an additional remark to these hints that "this functionality has not been implemented yet:.

Tested and installed correctly on 1.0.5 and shows the additional hints correctly. I did not add a new device to test if the DefaultConfiguration is parsed correctly; assume that this has been done at Athom prior to the release of 1.0.5

Since I updated to 1.0.5, I'm not able to do a regression test of this App on 1.0.4... Please check and or update the Homey SW dependency (to >=1.0.5).