### PR TITLE
Poll interval per capability + meter reset

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+	extends: "athom",
+};

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # Greenwave Systems
 
 This app adds support for devices made by [Greenwave Systems](http://www.greenwavesystems.com).
+
+## Supported devices with most common parameters:
+* Greenwave powernode-1
+* Greenwave powernode-6
+
+## Supported Languages:
+* English
+* Dutch
+
+## Change Log:
+
+### v 1.2.0
+**update:**
+All devices - add ability to differentiate polling interval for all capabilities    
+All devices - add Power Meter reset flow card  
+All devices - update Z-wave driver (1.1.7), code clean-up, minor fixes   

--- a/app.json
+++ b/app.json
@@ -11,8 +11,7 @@
 		"email": "info@athom.com"
 	},
 	"contributors": {
-		"developers": [
-			{
+		"developers": [{
 				"name": "Rex Markesteijn",
 				"email": "rmarkesteijn79@gmail.com"
 			},
@@ -23,6 +22,41 @@
 			{
 				"name": "Ted Tolboom",
 				"email": "dTNL.Homey@gmail.com"
+			}
+		]
+	},
+	"flow": {
+		"actions": [{
+				"id": "PN1_reset_meter",
+				"title": {
+					"en": "Reset meter values",
+					"nl": "Meter waarden resetten"
+				},
+				"hint": {
+					"en": "Reset the accumulated power usage (kWh). Can not be reversed.",
+					"nl": "Reset de stroomverbruik (kWh) waarden. Kan niet ongedaan gemaakt worden. "
+				},
+				"args": [{
+					"name": "device",
+					"type": "device",
+					"filter": "driver_id=powernode-1"
+				}]
+			},
+			{
+				"id": "PN6_reset_meter",
+				"title": {
+					"en": "Reset meter values",
+					"nl": "Meter waarden resetten"
+				},
+				"hint": {
+					"en": "Reset the accumulated power usage (kWh). Can not be reversed.",
+					"nl": "Reset de stroomverbruik (kWh) waarden. Kan niet ongedaan gemaakt worden. "
+				},
+				"args": [{
+					"name": "device",
+					"type": "device",
+					"filter": "driver_id=powernode-6"
+				}]
 			}
 		]
 	},
@@ -37,8 +71,7 @@
 		"large": "/assets/images/large.jpg",
 		"small": "/assets/images/small.jpg"
 	},
-	"drivers": [
-		{
+	"drivers": [{
 			"id": "powernode-1",
 			"name": {
 				"en": "Greenwave PowerNode 1",
@@ -100,8 +133,7 @@
 						}
 					}
 				},
-				"defaultConfiguration": [
-					{
+				"defaultConfiguration": [{
 						"id": 0,
 						"size": 1,
 						"value": 80
@@ -113,8 +145,7 @@
 					}
 				]
 			},
-			"settings": [
-				{
+			"settings": [{
 					"id": 0,
 					"type": "number",
 					"attr": {
@@ -149,20 +180,54 @@
 					}
 				},
 				{
-					"id": "poll_interval",
+					"id": "poll_interval_onoff",
 					"type": "number",
 					"attr": {
-						"min": 60,
-						"max": 3600
+						"min": 0,
+						"max": 7200
 					},
 					"value": 300,
 					"label": {
-						"en": "Poll Interval",
-						"nl": "Poll Interval"
+						"en": "Poll Interval On/Off",
+						"nl": "Poll Interval On/Off"
 					},
 					"hint": {
-						"en": "The amount of seconds between asking the device for a status update, default: 300 [s].",
-						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, standaard: 300 [s]."
+						"en": "The amount of seconds between asking the device for a status update, \nrange: 0 - 7200\n0: polling disabled \ndefault: 300 [s].",
+						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, \nbereik: 0 - 7200 \n0: polling uitgeschakeld \nstandaard: 300 [s]."
+					}
+				},
+				{
+					"id": "poll_interval_measure",
+					"type": "number",
+					"attr": {
+						"min": 0,
+						"max": 7200
+					},
+					"value": 300,
+					"label": {
+						"en": "Poll Interval Measure (W)",
+						"nl": "Poll Interval Measure (W)"
+					},
+					"hint": {
+						"en": "The amount of seconds between asking the device for a status update, \nrange: 0 - 7200\n0: polling disabled \ndefault: 300 [s].",
+						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, \nbereik: 0 - 7200 \n0: polling uitgeschakeld \nstandaard: 300 [s]."
+					}
+				},
+				{
+					"id": "poll_interval_meter",
+					"type": "number",
+					"attr": {
+						"min": 0,
+						"max": 7200
+					},
+					"value": 300,
+					"label": {
+						"en": "Poll Interval Meter (kWh)",
+						"nl": "Poll Interval Meter (kWh)"
+					},
+					"hint": {
+						"en": "The amount of seconds between asking the device for a status update, \nrange: 0 - 7200\n0: polling disabled \ndefault: 300 [s].",
+						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, \nbereik: 0 - 7200 \n0: polling uitgeschakeld \nstandaard: 300 [s]."
 					}
 				}
 			]
@@ -229,8 +294,7 @@
 						}
 					}
 				},
-				"defaultConfiguration": [
-					{
+				"defaultConfiguration": [{
 						"id": 0,
 						"size": 1,
 						"value": 80
@@ -316,8 +380,7 @@
 					}
 				}
 			},
-			"settings": [
-				{
+			"settings": [{
 					"id": 0,
 					"type": "number",
 					"attr": {
@@ -352,20 +415,54 @@
 					}
 				},
 				{
-					"id": "poll_interval",
+					"id": "poll_interval_onoff",
 					"type": "number",
 					"attr": {
-						"min": 60,
-						"max": 3600
+						"min": 0,
+						"max": 7200
 					},
 					"value": 300,
 					"label": {
-						"en": "Poll Interval",
-						"nl": "Poll Interval"
+						"en": "Poll Interval On/Off",
+						"nl": "Poll Interval On/Off"
 					},
 					"hint": {
-						"en": "The amount of seconds between asking the device for a status update, default: 300 [s].",
-						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, standaard: 300 [s]."
+						"en": "The amount of seconds between asking the device for a status update, \nrange: 0 - 7200\n0: polling disabled \ndefault: 300 [s].",
+						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, \nbereik: 0 - 7200 \n0: polling uitgeschakeld \nstandaard: 300 [s]."
+					}
+				},
+				{
+					"id": "poll_interval_measure",
+					"type": "number",
+					"attr": {
+						"min": 0,
+						"max": 7200
+					},
+					"value": 300,
+					"label": {
+						"en": "Poll Interval Measure (W)",
+						"nl": "Poll Interval Measure (W)"
+					},
+					"hint": {
+						"en": "The amount of seconds between asking the device for a status update, \nrange: 0 - 7200\n0: polling disabled \ndefault: 300 [s].",
+						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, \nbereik: 0 - 7200 \n0: polling uitgeschakeld \nstandaard: 300 [s]."
+					}
+				},
+				{
+					"id": "poll_interval_meter",
+					"type": "number",
+					"attr": {
+						"min": 0,
+						"max": 7200
+					},
+					"value": 300,
+					"label": {
+						"en": "Poll Interval Meter (kWh)",
+						"nl": "Poll Interval Meter (kWh)"
+					},
+					"hint": {
+						"en": "The amount of seconds between asking the device for a status update, \nrange: 0 - 7200\n0: polling disabled \ndefault: 300 [s].",
+						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, \nbereik: 0 - 7200 \n0: polling uitgeschakeld \nstandaard: 300 [s]."
 					}
 				}
 			]

--- a/drivers/powernode-1/driver.js
+++ b/drivers/powernode-1/driver.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 const path = require('path');
 const ZwaveDriver = require('homey-zwavedriver');
@@ -6,77 +6,91 @@ const ZwaveDriver = require('homey-zwavedriver');
 // http://www.pepper1.net/zwavedb/device/280
 
 module.exports = new ZwaveDriver(path.basename(__dirname), {
+	debug: false,
 	capabilities: {
-		'onoff': {
-			'command_class': 'COMMAND_CLASS_SWITCH_BINARY',
-			'command_get': 'SWITCH_BINARY_GET',
-			'command_get_cb': false,
-			'command_set': 'SWITCH_BINARY_SET',
-			'command_set_parser': function (value) {
-				return {
-					'Switch Value': value
-				}
-			},
-			'command_report': 'SWITCH_BINARY_REPORT',
-			'command_report_parser': function (report) {
-				return report['Value'] === 'on/enable';
-			},
-			'pollInterval': "poll_interval"
+		onoff: {
+			command_class: 'COMMAND_CLASS_SWITCH_BINARY',
+			command_get: 'SWITCH_BINARY_GET',
+			command_get_cb: false,
+			command_set: 'SWITCH_BINARY_SET',
+			command_set_parser: value => ({
+				'Switch Value': value,
+			}),
+			command_report: 'SWITCH_BINARY_REPORT',
+			command_report_parser: report => report.Value === 'on/enable',
+			pollInterval: 'poll_interval_onoff',
 		},
-		'measure_power': {
-			'command_class': 'COMMAND_CLASS_METER',
-			'command_get': 'METER_GET',
-			'command_get_cb': false,
-			'command_get_parser': function () {
-				return {
-					'Properties1': {
-						'Scale': 2
-					}
-				}
-			},
-			'command_report': 'METER_REPORT',
-			'command_report_parser': function (report) {
-				if (report && report.hasOwnProperty('Properties2')
-					&& report.Properties2.hasOwnProperty('Scale')
-					&& report.Properties2['Scale'] === 2) {
-
+		measure_power: {
+			command_class: 'COMMAND_CLASS_METER',
+			command_get: 'METER_GET',
+			command_get_cb: false,
+			command_get_parser: () => ({
+				Properties1: {
+					Scale: 2,
+				},
+			}),
+			command_report: 'METER_REPORT',
+			command_report_parser: report => {
+				if (report.hasOwnProperty('Properties2') &&
+					report.Properties2.hasOwnProperty('Scale') &&
+					report.Properties2.Scale === 2) {
 					return report['Meter Value (Parsed)'];
-				} else return null;
+				}
+
+				return null;
 			},
-			'pollInterval': "poll_interval"
+			pollInterval: 'poll_interval_measure',
 		},
-		'meter_power': {
-			'command_class': 'COMMAND_CLASS_METER',
-			'command_get': 'METER_GET',
-			'command_get_cb': false,
-			'command_get_parser': function () {
-				return {
-					'Properties1': {
-						'Scale': 0
-					}
-				}
-			},
-			'command_report': 'METER_REPORT',
-			'command_report_parser': function (report) {
-				if (report && report.hasOwnProperty('Properties2')
-					&& report.Properties2.hasOwnProperty('Scale')
-					&& report.Properties2['Scale'] === 0) {
 
+		meter_power: {
+			command_class: 'COMMAND_CLASS_METER',
+			command_get: 'METER_GET',
+			command_get_cb: false,
+			command_get_parser: () => ({
+				Properties1: {
+					Scale: 0,
+				},
+			}),
+			command_report: 'METER_REPORT',
+			command_report_parser: report => {
+				if (report.hasOwnProperty('Properties2') &&
+					report.Properties2.hasOwnProperty('Scale') &&
+					report.Properties2.Scale === 0) {
 					return report['Meter Value (Parsed)'];
-				} else return null;
+				}
+				return null;
 			},
-			'pollInterval': "poll_interval"
-		}
+			pollInterval: 'poll_interval_meter',
+		},
 	},
 	settings: {
 		0: {
-			"index": 0,
-			"size": 1,
+			index: 0,
+			size: 1,
 		},
 		1: {
-			"index": 1,
-			"size": 1,
-			"signed": false,
-		}
-	}
+			index: 1,
+			size: 1,
+			signed: false,
+		},
+	},
+});
+
+Homey.manager('flow').on('action.PN1_reset_meter', (callback, args) => {
+	const node = module.exports.nodes[args.device.token];
+
+	if (node &&
+		node.instance.CommandClass.COMMAND_CLASS_METER) {
+		node.instance.CommandClass.COMMAND_CLASS_METER.METER_RESET({}, (err, result) => {
+			if (err) return callback(err);
+
+			// If properly transmitted, change the setting and finish flow card
+			if (result === 'TRANSMIT_COMPLETE_OK') {
+
+				return callback(null, true);
+			}
+
+			return callback('unknown_response');
+		});
+	} else return callback('unknown_error');
 });

--- a/drivers/powernode-6/driver.js
+++ b/drivers/powernode-6/driver.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 const path = require('path');
 const ZwaveDriver = require('homey-zwavedriver');
@@ -6,78 +6,92 @@ const ZwaveDriver = require('homey-zwavedriver');
 // http://www.pepper1.net/zwavedb/device/280
 
 module.exports = new ZwaveDriver(path.basename(__dirname), {
+	debug: false,
 	capabilities: {
-		'onoff': {
-			'command_class': 'COMMAND_CLASS_SWITCH_BINARY',
-			'command_get': 'SWITCH_BINARY_GET',
-			'command_get_cb': false,
-			'command_set': 'SWITCH_BINARY_SET',
-			'command_set_parser': function (value) {
-				return {
-					'Switch Value': value
-				}
-			},
-			'command_report': 'SWITCH_BINARY_REPORT',
-			'command_report_parser': function (report) {
-				return report['Value'] === 'on/enable';
-			},
-			'pollInterval': "poll_interval"
+		onoff: {
+			command_class: 'COMMAND_CLASS_SWITCH_BINARY',
+			command_get: 'SWITCH_BINARY_GET',
+			command_get_cb: false,
+			command_set: 'SWITCH_BINARY_SET',
+			command_set_parser: value => ({
+				'Switch Value': value,
+			}),
+			command_report: 'SWITCH_BINARY_REPORT',
+			command_report_parser: report => report.Value === 'on/enable',
+			pollInterval: 'poll_interval_onoff',
 		},
-		'measure_power': {
-			'command_class': 'COMMAND_CLASS_METER',
-			'command_get': 'METER_GET',
-			'command_get_cb': false,
-			'command_get_parser': function () {
-				return {
-					'Properties1': {
-						'Scale': 2
-					}
-				}
-			},
-			'command_report': 'METER_REPORT',
-			'command_report_parser': function (report) {
-				if (report && report.hasOwnProperty('Properties2')
-					&& report.Properties2.hasOwnProperty('Scale')
-					&& report.Properties2['Scale'] === 2) {
-
+		measure_power: {
+			command_class: 'COMMAND_CLASS_METER',
+			command_get: 'METER_GET',
+			command_get_cb: false,
+			command_get_parser: () => ({
+				Properties1: {
+					Scale: 2,
+				},
+			}),
+			command_report: 'METER_REPORT',
+			command_report_parser: report => {
+				if (report.hasOwnProperty('Properties2') &&
+					report.Properties2.hasOwnProperty('Scale') &&
+					report.Properties2.Scale === 2) {
 					return report['Meter Value (Parsed)'];
-				} else return null;
+				}
+
+				return null;
 			},
-			'pollInterval': "poll_interval"
+			pollInterval: 'poll_interval_meter',
 		},
 
-		'meter_power': {
-			'command_class': 'COMMAND_CLASS_METER',
-			'command_get': 'METER_GET',
-			'command_get_cb': false,
-			'command_get_parser': function () {
-				return {
-					'Properties1': {
-						'Scale': 0
-					}
-				}
-			},
-			'command_report': 'METER_REPORT',
-			'command_report_parser': function (report) {
-				if (report && report.hasOwnProperty('Properties2')
-					&& report.Properties2.hasOwnProperty('Scale')
-					&& report.Properties2['Scale'] === 0) {
-
+		meter_power: {
+			command_class: 'COMMAND_CLASS_METER',
+			command_get: 'METER_GET',
+			command_get_cb: false,
+			command_get_parser: () => ({
+				Properties1: {
+					Scale: 0,
+				},
+			}),
+			command_report: 'METER_REPORT',
+			command_report_parser: report => {
+				if (report.hasOwnProperty('Properties2') &&
+					report.Properties2.hasOwnProperty('Scale') &&
+					report.Properties2.Scale === 0) {
 					return report['Meter Value (Parsed)'];
-				} else return null;
+				}
+
+				return null;
 			},
-			'pollInterval': "poll_interval"
-		}
+			pollInterval: 'poll_interval_measure',
+		},
 	},
 	settings: {
 		0: {
-			"index": 0,
-			"size": 1,
+			index: 0,
+			size: 1,
 		},
 		1: {
-			"index": 1,
-			"size": 1,
-			"signed": false,
-		}
-	}
+			index: 1,
+			size: 1,
+			signed: false,
+		},
+	},
+});
+
+Homey.manager('flow').on('action.PN6_reset_meter', (callback, args) => {
+	const node = module.exports.nodes[args.device.token];
+
+	if (node &&
+		node.instance.CommandClass.COMMAND_CLASS_METER) {
+		node.instance.CommandClass.COMMAND_CLASS_METER.METER_RESET({}, (err, result) => {
+			if (err) return callback(err);
+
+			// If properly transmitted, change the setting and finish flow card
+			if (result === 'TRANSMIT_COMPLETE_OK') {
+
+				return callback(null, true);
+			}
+
+			return callback('unknown_response');
+		});
+	} else return callback('unknown_error');
 });


### PR DESCRIPTION
Requires: https://github.com/athombv/node-homey-zwavedriver/pull/32

Changelog:
All devices - add ability to differentiate polling interval for all
capabilities
All devices - add Power Meter reset flow card
All devices - update Z-wave driver (1.1.7), code clean-up, minor fixes

Tested for 2 weeks on setup with 5 powernode-6's and 1 powernode-1; working OK and reducing the amount of queue_full errors substantially.