### PR TITLE
Split polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ This app adds support for devices made by [Greenwave Systems](http://www.greenwa
 * Dutch
 
 ## Changelog:
+### v1.1.2 - (save settings (once) to activate all polling intervals)
+Powernode 6 - add polling intervals for each separate socket and its capabilities
 
-### v1.1.0 - (re-pair of devices is needed)
+### v1.1.0 & v1.1.1 - (re-pair of devices is needed)
 **update:**
 
 All devices - add ability to differentiate polling interval for all capabilities    

--- a/app.json
+++ b/app.json
@@ -43,8 +43,8 @@
 						"name": "device",
 						"type": "device",
 						"filter": "driver_id=powernode-1"
-					}
-				]
+				}
+			]
 			},
 			{
 				"id": "PN6_reset_meter",
@@ -61,8 +61,8 @@
 						"name": "device",
 						"type": "device",
 						"filter": "driver_id=powernode-6"
-					}
-				]
+				}
+			]
 			}
 		]
 	},
@@ -196,7 +196,7 @@
 							"type": "number",
 							"attr": {
 								"min": 0,
-								"max": 7200
+								"max": 86400
 							},
 							"value": 0,
 							"label": {
@@ -204,33 +204,33 @@
 								"nl": "Poll interval on/off"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 300 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 300 seconden."
 							}
-						},
+					},
 						{
 							"id": "poll_interval_measure",
 							"type": "number",
 							"attr": {
 								"min": 0,
-								"max": 7200
+								"max": 86400
 							},
-							"value": 600,
+							"value": 900,
 							"label": {
 								"en": "Poll interval measure (W)",
 								"nl": "Poll interval measure (W)"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 900 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 900 seconden."
 							}
-						},
+					},
 						{
 							"id": "poll_interval_meter",
 							"type": "number",
 							"attr": {
 								"min": 0,
-								"max": 7200
+								"max": 86400
 							},
 							"value": 3600,
 							"label": {
@@ -238,14 +238,14 @@
 								"nl": "Poll interval meter (kWh)"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 3600 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 3600 seconden."
 							}
-						}
+					}
 					]
-				}
+			}
 			]
-		},
+	},
 		{
 			"id": "powernode-6",
 			"name": {
@@ -444,7 +444,7 @@
 							"type": "number",
 							"attr": {
 								"min": 0,
-								"max": 7200
+								"max": 86400
 							},
 							"value": 0,
 							"label": {
@@ -452,8 +452,8 @@
 								"nl": "Aan/uit"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 300 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 300 seconden."
 							}
 						},
 						{
@@ -461,7 +461,7 @@
 							"type": "number",
 							"attr": {
 								"min": 0,
-								"max": 7200
+								"max": 86400
 							},
 							"value": 600,
 							"label": {
@@ -469,8 +469,8 @@
 								"nl": "Vermogen (W)"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 600 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 600 seconden."
 							}
 						},
 						{
@@ -478,7 +478,7 @@
 							"type": "number",
 							"attr": {
 								"min": 0,
-								"max": 7200
+								"max": 86400
 							},
 							"value": 3600,
 							"label": {
@@ -486,8 +486,8 @@
 								"nl": "Energieverbruik (kWh)"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 3600 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 3600 seconden."
 							}
 						}
 					]
@@ -505,7 +505,7 @@
 							"type": "number",
 							"attr": {
 								"min": 0,
-								"max": 7200
+								"max": 86400
 							},
 							"value": 0,
 							"label": {
@@ -513,8 +513,8 @@
 								"nl": "Aan/uit"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 300 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 300 seconden."
 							}
 						},
 						{
@@ -522,16 +522,16 @@
 							"type": "number",
 							"attr": {
 								"min": 0,
-								"max": 7200
+								"max": 86400
 							},
-							"value": 600,
+							"value": 605,
 							"label": {
 								"en": "Wattage",
 								"nl": "Wattage"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 605 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 605 seconden."
 							}
 						},
 						{
@@ -539,16 +539,16 @@
 							"type": "number",
 							"attr": {
 								"min": 0,
-								"max": 7200
+								"max": 86400
 							},
-							"value": 3600,
+							"value": 3605,
 							"label": {
 								"en": "KiloWattHour (kWh)",
 								"nl": "KiloWattUur (kWh)"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 3605 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 3605 seconden."
 							}
 						}
 					]
@@ -566,7 +566,7 @@
 							"type": "number",
 							"attr": {
 								"min": 0,
-								"max": 7200
+								"max": 86400
 							},
 							"value": 0,
 							"label": {
@@ -574,8 +574,8 @@
 								"nl": "Aan/uit"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 300 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 300 seconden."
 							}
 						},
 						{
@@ -583,16 +583,16 @@
 							"type": "number",
 							"attr": {
 								"min": 0,
-								"max": 7200
+								"max": 86400
 							},
-							"value": 600,
+							"value": 610,
 							"label": {
 								"en": "Wattage",
 								"nl": "Wattage"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 610 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 610 seconden."
 							}
 						},
 						{
@@ -600,16 +600,16 @@
 							"type": "number",
 							"attr": {
 								"min": 0,
-								"max": 7200
+								"max": 86400
 							},
-							"value": 3600,
+							"value": 3610,
 							"label": {
 								"en": "KiloWattHour (kWh)",
 								"nl": "KiloWattUur (kWh)"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 3610 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 3610 seconden."
 							}
 						}
 					]
@@ -627,7 +627,7 @@
 							"type": "number",
 							"attr": {
 								"min": 0,
-								"max": 7200
+								"max": 86400
 							},
 							"value": 0,
 							"label": {
@@ -635,8 +635,8 @@
 								"nl": "Aan/uit"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 300 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 300 seconden."
 							}
 						},
 						{
@@ -644,16 +644,16 @@
 							"type": "number",
 							"attr": {
 								"min": 0,
-								"max": 7200
+								"max": 86400
 							},
-							"value": 600,
+							"value": 615,
 							"label": {
 								"en": "Wattage",
 								"nl": "Wattage"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 615 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 615 seconden."
 							}
 						},
 						{
@@ -661,16 +661,16 @@
 							"type": "number",
 							"attr": {
 								"min": 0,
-								"max": 7200
+								"max": 86400
 							},
-							"value": 3600,
+							"value": 3615,
 							"label": {
 								"en": "KiloWattHour (kWh)",
 								"nl": "KiloWattUur (kWh)"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 3615 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 3615 seconden."
 							}
 						}
 					]
@@ -688,7 +688,7 @@
 							"type": "number",
 							"attr": {
 								"min": 0,
-								"max": 7200
+								"max": 86400
 							},
 							"value": 0,
 							"label": {
@@ -696,8 +696,8 @@
 								"nl": "Aan/uit"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 300 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 300 seconden."
 							}
 						},
 						{
@@ -705,16 +705,16 @@
 							"type": "number",
 							"attr": {
 								"min": 0,
-								"max": 7200
+								"max": 86400
 							},
-							"value": 600,
+							"value": 620,
 							"label": {
 								"en": "Wattage",
 								"nl": "Wattage"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault:620 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde:620 seconden."
 							}
 						},
 						{
@@ -722,16 +722,16 @@
 							"type": "number",
 							"attr": {
 								"min": 0,
-								"max": 7200
+								"max": 86400
 							},
-							"value": 3600,
+							"value": 3620,
 							"label": {
 								"en": "KiloWattHour (kWh)",
 								"nl": "KiloWattUur (kWh)"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 3620 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 3620 seconden."
 							}
 						}
 					]
@@ -749,7 +749,7 @@
 							"type": "number",
 							"attr": {
 								"min": 0,
-								"max": 7200
+								"max": 86400
 							},
 							"value": 0,
 							"label": {
@@ -757,8 +757,8 @@
 								"nl": "Aan/uit"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 300 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 300 seconden."
 							}
 						},
 						{
@@ -766,16 +766,16 @@
 							"type": "number",
 							"attr": {
 								"min": 0,
-								"max": 7200
+								"max": 86400
 							},
-							"value": 600,
+							"value": 625,
 							"label": {
 								"en": "Wattage",
 								"nl": "Wattage"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault:625 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde:625 seconden."
 							}
 						},
 						{
@@ -783,16 +783,16 @@
 							"type": "number",
 							"attr": {
 								"min": 0,
-								"max": 7200
+								"max": 86400
 							},
-							"value": 3600,
+							"value": 3625,
 							"label": {
 								"en": "KiloWattHour (kWh)",
 								"nl": "KiloWattUur (kWh)"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 3625 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 3625 seconden."
 							}
 						}
 					]
@@ -810,7 +810,7 @@
 							"type": "number",
 							"attr": {
 								"min": 0,
-								"max": 7200
+								"max": 86400
 							},
 							"value": 0,
 							"label": {
@@ -818,8 +818,8 @@
 								"nl": "Aan/uit"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 300 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 300 seconden."
 							}
 						},
 						{
@@ -827,16 +827,16 @@
 							"type": "number",
 							"attr": {
 								"min": 0,
-								"max": 7200
+								"max": 86400
 							},
-							"value": 600,
+							"value": 630,
 							"label": {
 								"en": "Wattage",
 								"nl": "Wattage"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault:630 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde:630 seconden."
 							}
 						},
 						{
@@ -844,16 +844,16 @@
 							"type": "number",
 							"attr": {
 								"min": 0,
-								"max": 7200
+								"max": 86400
 							},
-							"value": 3600,
+							"value": 3630,
 							"label": {
 								"en": "KiloWattHour (kWh)",
 								"nl": "KiloWattUur (kWh)"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 3630 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 3630 seconden."
 							}
 						}
 					]

--- a/app.json
+++ b/app.json
@@ -317,7 +317,8 @@
             ],
             "icon": "/drivers/powernode-6/assets/icon-1.svg",
             "name": {
-              "en": "Greenwave PowerNode Socket 1"
+              "en": "Greenwave PowerNode Socket 1",
+              "nl": "Greenwave PowerNode Stopcontact 1"
             }
           },
           "2": {
@@ -329,7 +330,8 @@
             ],
             "icon": "/drivers/powernode-6/assets/icon-2.svg",
             "name": {
-              "en": "Greenwave PowerNode Socket 2"
+              "en": "Greenwave PowerNode Socket 2",
+              "nl": "Greenwave PowerNode Stopcontact 2"
             }
           },
           "3": {
@@ -341,7 +343,8 @@
             ],
             "icon": "/drivers/powernode-6/assets/icon-3.svg",
             "name": {
-              "en": "Greenwave PowerNode Socket 3"
+              "en": "Greenwave PowerNode Socket 3",
+              "nl": "Greenwave PowerNode Stopcontact 3"
             }
           },
           "4": {
@@ -353,7 +356,8 @@
             ],
             "icon": "/drivers/powernode-6/assets/icon-4.svg",
             "name": {
-              "en": "Greenwave PowerNode Socket 4"
+              "en": "Greenwave PowerNode Socket 4",
+              "nl": "Greenwave PowerNode Stopcontact 4"
             }
           },
           "5": {
@@ -365,7 +369,8 @@
             ],
             "icon": "/drivers/powernode-6/assets/icon-5.svg",
             "name": {
-              "en": "Greenwave PowerNode Socket 5"
+              "en": "Greenwave PowerNode Socket 5",
+              "nl": "Greenwave PowerNode Stopcontact 5"
             }
           },
           "6": {
@@ -377,7 +382,8 @@
             ],
             "icon": "/drivers/powernode-6/assets/icon-6.svg",
             "name": {
-              "en": "Greenwave PowerNode Socket 6"
+              "en": "Greenwave PowerNode Socket 6",
+              "nl": "Greenwave PowerNode Stopcontact 6"
             }
           }
         }
@@ -417,57 +423,372 @@
             "nl": "Aantal minuten zonder contact tussen controller en apparaat voordat het apparaat groen gaat knipperen, standaard: 255 [min]."
           }
         },
-        {
-          "id": "poll_interval_onoff",
-          "type": "number",
-          "attr": {
-            "min": 0,
-            "max": 7200
-          },
-          "value": 300,
-          "label": {
-            "en": "Poll interval on/off",
-            "nl": "Poll interval on/off"
-          },
-          "hint": {
-            "en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
-            "nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
-          }
-        },
-        {
-          "id": "poll_interval_measure",
-          "type": "number",
-          "attr": {
-            "min": 0,
-            "max": 7200
-          },
-          "value": 600,
-          "label": {
-            "en": "Poll interval measure (W)",
-            "nl": "Poll interval measure (W)"
-          },
-          "hint": {
-            "en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
-            "nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
-          }
-        },
-        {
-          "id": "poll_interval_meter",
-          "type": "number",
-          "attr": {
-            "min": 0,
-            "max": 7200
-          },
-          "value": 3600,
-          "label": {
-            "en": "Poll interval meter (kWh)",
-            "nl": "Poll interval meter (kWh)"
-          },
-          "hint": {
-            "en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
-            "nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
-          }
-        }
+    		{
+    			"type": "group",
+    			"label": {
+    				"en": "Poll State socket 1",
+    				"nl": "Poll Status stopcontact 1"
+    			},
+    			"collapsed": true,
+    			"children": [
+    				{
+    					"id": "poll_onoff_1",
+    					"type": "number",
+    					"attr": {
+    						"min": 0,
+    						"max": 7200
+    					},
+    					"value": 300,
+    					"label": {
+    						"en": "On/off",
+    						"nl": "Aan/uit"
+    					},
+    					"hint": {
+    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
+    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
+    					}
+    				},
+    				{
+    					"id": "poll_measure_1",
+    					"type": "number",
+    					"attr": {
+    						"min": 0,
+    						"max": 7200
+    					},
+    					"value": 600,
+    					"label": {
+    						"en": "Wattage",
+    						"nl": "Wattage"
+    					},
+    					"hint": {
+    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
+    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
+    					}
+    				},
+    				{
+    					"id": "poll_meter_1",
+    					"type": "number",
+    					"attr": {
+    						"min": 0,
+    						"max": 7200
+    					},
+    					"value": 3600,
+    					"label": {
+    						"en": "KiloWattHour (kWh)",
+    						"nl": "KiloWattUur (kWh)"
+    					},
+    					"hint": {
+    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
+    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
+    					}
+    				}
+    			]
+    		},
+    		{
+    			"type": "group",
+    			"label": {
+    				"en": "Poll state socket 2",
+    				"nl": "Poll status stopcontact 2"
+    			},
+    			"collapsed": true,
+    			"children": [
+    				{
+    					"id": "poll_onoff_2",
+    					"type": "number",
+    					"attr": {
+    						"min": 0,
+    						"max": 7200
+    					},
+    					"value": 300,
+    					"label": {
+    						"en": "On/off",
+    						"nl": "Aan/uit"
+    					},
+    					"hint": {
+    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
+    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
+    					}
+    				},
+    				{
+    					"id": "poll_measure_2",
+    					"type": "number",
+    					"attr": {
+    						"min": 0,
+    						"max": 7200
+    					},
+    					"value": 600,
+    					"label": {
+    						"en": "Wattage",
+    						"nl": "Wattage"
+    					},
+    					"hint": {
+    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
+    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
+    					}
+    				},
+    				{
+    					"id": "poll_meter_2",
+    					"type": "number",
+    					"attr": {
+    						"min": 0,
+    						"max": 7200
+    					},
+    					"value": 3600,
+    					"label": {
+    						"en": "KiloWattHour (kWh)",
+    						"nl": "KiloWattUur (kWh)"
+    					},
+    					"hint": {
+    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
+    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
+    					}
+    				}
+    			]
+    		},
+    		{
+    			"type": "group",
+    			"label": {
+    				"en": "Poll state socket 3",
+    				"nl": "Poll status stopcontact 3"
+    			},
+    			"collapsed": true,
+    			"children": [
+    				{
+    					"id": "poll_onoff_3",
+    					"type": "number",
+    					"attr": {
+    						"min": 0,
+    						"max": 7200
+    					},
+    					"value": 300,
+    					"label": {
+    						"en": "On/off",
+    						"nl": "Aan/uit"
+    					},
+    					"hint": {
+    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
+    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
+    					}
+    				},
+    				{
+    					"id": "poll_measure_3",
+    					"type": "number",
+    					"attr": {
+    						"min": 0,
+    						"max": 7200
+    					},
+    					"value": 600,
+    					"label": {
+    						"en": "Wattage",
+    						"nl": "Wattage"
+    					},
+    					"hint": {
+    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
+    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
+    					}
+    				},
+    				{
+    					"id": "poll_meter_3",
+    					"type": "number",
+    					"attr": {
+    						"min": 0,
+    						"max": 7200
+    					},
+    					"value": 3600,
+    					"label": {
+    						"en": "KiloWattHour (kWh)",
+    						"nl": "KiloWattUur (kWh)"
+    					},
+    					"hint": {
+    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
+    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
+    					}
+    				}
+    			]
+    		},
+    		{
+    			"type": "group",
+    			"label": {
+    				"en": "Poll state socket 4",
+    				"nl": "Poll status stopcontact 4"
+    			},
+    			"collapsed": true,
+    			"children": [
+    				{
+    					"id": "poll_onoff_4",
+    					"type": "number",
+    					"attr": {
+    						"min": 0,
+    						"max": 7200
+    					},
+    					"value": 30,
+    					"label": {
+    						"en": "On/off",
+    						"nl": "Aan/uit"
+    					},
+    					"hint": {
+    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
+    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
+    					}
+    				},
+    				{
+    					"id": "poll_measure_4",
+    					"type": "number",
+    					"attr": {
+    						"min": 0,
+    						"max": 7200
+    					},
+    					"value": 600,
+    					"label": {
+    						"en": "Wattage",
+    						"nl": "Wattage"
+    					},
+    					"hint": {
+    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
+    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
+    					}
+    				},
+    				{
+    					"id": "poll_meter_4",
+    					"type": "number",
+    					"attr": {
+    						"min": 0,
+    						"max": 7200
+    					},
+    					"value": 3600,
+    					"label": {
+    						"en": "KiloWattHour (kWh)",
+    						"nl": "KiloWattUur (kWh)"
+    					},
+    					"hint": {
+    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
+    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
+    					}
+    				}
+    			]
+    		},
+    		{
+    			"type": "group",
+    			"label": {
+    				"en": "Poll state socket 5",
+    				"nl": "Poll status stopcontact 5"
+    			},
+    			"collapsed": true,
+    			"children": [
+    				{
+    					"id": "poll_onoff_5",
+    					"type": "number",
+    					"attr": {
+    						"min": 0,
+    						"max": 7200
+    					},
+    					"value": 300,
+    					"label": {
+    						"en": "On/off",
+    						"nl": "Aan/uit"
+    					},
+    					"hint": {
+    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
+    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
+    					}
+    				},
+    				{
+    					"id": "poll_measure_5",
+    					"type": "number",
+    					"attr": {
+    						"min": 0,
+    						"max": 7200
+    					},
+    					"value": 600,
+    					"label": {
+    						"en": "Wattage",
+    						"nl": "Wattage"
+    					},
+    					"hint": {
+    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
+    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
+    					}
+    				},
+    				{
+    					"id": "poll_meter_5",
+    					"type": "number",
+    					"attr": {
+    						"min": 0,
+    						"max": 7200
+    					},
+    					"value": 3600,
+    					"label": {
+    						"en": "KiloWattHour (kWh)",
+    						"nl": "KiloWattUur (kWh)"
+    					},
+    					"hint": {
+    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
+    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
+    					}
+    				}
+    			]
+    		},
+    		{
+    			"type": "group",
+    			"label": {
+    				"en": "Poll state socket 6",
+    				"nl": "Poll status stopcontact 6"
+    			},
+    			"collapsed": true,
+    			"children": [
+    				{
+    					"id": "poll_onoff_6",
+    					"type": "number",
+    					"attr": {
+    						"min": 0,
+    						"max": 7200
+    					},
+    					"value": 300,
+    					"label": {
+    						"en": "On/off",
+    						"nl": "Aan/uit"
+    					},
+    					"hint": {
+    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
+    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
+    					}
+    				},
+    				{
+    					"id": "poll_measure_6",
+    					"type": "number",
+    					"attr": {
+    						"min": 0,
+    						"max": 7200
+    					},
+    					"value": 600,
+    					"label": {
+    						"en": "Wattage",
+    						"nl": "Wattage"
+    					},
+    					"hint": {
+    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
+    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
+    					}
+    				},
+    				{
+    					"id": "poll_meter_6",
+    					"type": "number",
+    					"attr": {
+    						"min": 0,
+    						"max": 7200
+    					},
+    					"value": 3600,
+    					"label": {
+    						"en": "KiloWattHour (kWh)",
+    						"nl": "KiloWattUur (kWh)"
+    					},
+    					"hint": {
+    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
+    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
+    					}
+    				}
+    			]
+    		}
       ]
     }
   ]

--- a/app.json
+++ b/app.json
@@ -1,795 +1,864 @@
 {
-  "id": "com.greenwavesystems",
-  "name": {
-    "en": "Greenwave Systems",
-    "nl": "Greenwave Systems"
-  },
-  "version": "1.1.1",
-  "compatibility": ">=1.0.5",
-  "author": {
-    "name": "Athom B.V.",
-    "email": "info@athom.com"
-  },
-  "contributors": {
-    "developers": [
-      {
-        "name": "Rex Markesteijn",
-        "email": "rmarkesteijn79@gmail.com"
-      },
-      {
-        "name": "Jelger Haanstra",
-        "email": "homey@solidewebservices.com"
-      },
-      {
-        "name": "Ted Tolboom",
-        "email": "dTNL.Homey@gmail.com"
-      }
-    ]
-  },
-  "flow": {
-    "actions": [
-      {
-        "id": "PN1_reset_meter",
-        "title": {
-          "en": "Reset meter values",
-          "nl": "Meter waarden resetten"
-        },
-        "hint": {
-          "en": "Reset the accumulated power usage (kWh). Can not be reversed.",
-          "nl": "Reset de stroomverbruik (kWh) waarden. Kan niet ongedaan worden gemaakt."
-        },
-        "args": [
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=powernode-1"
-          }
-        ]
-      },
-      {
-        "id": "PN6_reset_meter",
-        "title": {
-          "en": "Reset meter values",
-          "nl": "Meter waarden resetten"
-        },
-        "hint": {
-          "en": "Reset the accumulated power usage (kWh). Can not be reversed.",
-          "nl": "Reset de stroomverbruik (kWh) waarden. Kan niet ongedaan worden gemaakt."
-        },
-        "args": [
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=powernode-6"
-          }
-        ]
-      }
-    ]
-  },
-  "category": [
-    "appliances"
-  ],
-  "description": {
-    "en": "Drivers for Greenwave Systems devices",
-    "nl": "Drivers voor Greenwave Systems apparaten"
-  },
-  "images": {
-    "large": "/assets/images/large.jpg",
-    "small": "/assets/images/small.jpg"
-  },
-  "drivers": [
-    {
-      "id": "powernode-1",
-      "name": {
-        "en": "Greenwave PowerNode 1",
-        "nl": "Greenwave PowerNode 1"
-      },
-      "icon": "/drivers/powernode-1/assets/icon.svg",
-      "images": {
-        "large": "/drivers/powernode-1/assets/images/large.jpg",
-        "small": "/drivers/powernode-1/assets/images/small.jpg"
-      },
-      "class": "socket",
-      "capabilities": [
-        "onoff",
-        "measure_power",
-        "meter_power"
-      ],
-      "zwave": {
-        "manufacturerId": 153,
-        "productTypeId": 2,
-        "productId": 2,
-        "learnmode": {
-          "image": "/drivers/powernode-1/assets/learnmode.svg",
-          "instruction": {
-            "en": "Press the small button on your Greenwave PowerNode",
-            "nl": "Druk op de kleine knop op de Greenwave PowerNode"
-          }
-        },
-        "associationGroups": [
-          1,
-          3
-        ],
-        "associationGroupsOptions": {
-          "1": {
-            "hint": {
-              "en": "Reports the device status and allows control (ON/OFF) over the powernode (Homey ID by default). It is not recommended to change this group.",
-              "nl": "Rapportage van de status van de powernode en staat controle (AAN/UIT) over de powernode toe (Homey ID als standaard waarde). Het is niet aanbevolen om deze groep aan te passen."
-            }
-          },
-          "2": {
-            "hint": {
-              "en": "Reports alarm report when detecting current leakage of defined relay device if an association relationship has been defined (add Z-wave ID of relay device).",
-              "nl": "Rapportage van een alarm op het moment dat een lekstroom gedetecteerd wordt op een gekoppelds apparaat indien een relatie gedefineerd is (voeg het Z-wave ID van het te koppelen apparaat toe)."
-            }
-          },
-          "3": {
-            "hint": {
-              "en": "Reports the power value change if the difference of the instant power reading compared to previous report is larger than the -Power change for update- parameter set (e.g. 80%). (Homey ID by default)",
-              "nl": "Rapportage van de gebruikte energie wanneer het verschil met de vorige rapportage groter is dan de waarde ingesteld bij -Wijziging in energie voor update- parameter (bv. 80%). (Homey ID als standaard waarde)"
-            }
-          },
-          "4": {
-            "hint": {
-              "en": "Reports alarm when the powernode is in over-current protection and powers off a relay device if an association relationship has been defined (add Z-wave ID of relay device).",
-              "nl": "Alarm reportage wanneer de powernode in over-current protectie overschakeld en automatische uitschakeling van het gekoppelde apparaat indien een relatie gedefineerd is (voeg het Z-wave ID van het te koppelen apparaat toe)."
-            }
-          }
-        },
-        "defaultConfiguration": [
-          {
-            "id": 0,
-            "size": 1,
-            "value": 80
-          },
-          {
-            "id": 1,
-            "size": 1,
-            "value": "0xFF"
-          }
-        ]
-      },
-      "settings": [
-        {
-          "id": 0,
-          "type": "number",
-          "attr": {
-            "min": 1,
-            "max": 100
-          },
-          "value": 80,
-          "label": {
-            "en": "Power change for update",
-            "nl": "Wijziging in energie voor update"
-          },
-          "hint": {
-            "en": "Power change required to send an update to controller, in % from 1 to 100, default: 80 [%].",
-            "nl": "Wijziging in energie voordat er een update naar de controller wordt gestuurd, in % van 1 tot 100, standaard: 80 [%].."
-          }
-        },
-        {
-          "id": 1,
-          "type": "number",
-          "attr": {
-            "min": 1,
-            "max": 255
-          },
-          "value": 255,
-          "label": {
-            "en": "Keep alive time",
-            "nl": "Keep alive time"
-          },
-          "hint": {
-            "en": "The amount of minutes without contact between controller and device before the device starts blinking green, default: 255 [min].",
-            "nl": "Aantal minuten zonder contact tussen controller en apparaat voordat het apparaat groen gaat knipperen, standaard: 255 [min]."
-          }
-        },
-        {
-          "id": "poll_interval_onoff",
-          "type": "number",
-          "attr": {
-            "min": 0,
-            "max": 7200
-          },
-          "value": 300,
-          "label": {
-            "en": "Poll interval on/off",
-            "nl": "Poll interval on/off"
-          },
-          "hint": {
-            "en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
-            "nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
-          }
-        },
-        {
-          "id": "poll_interval_measure",
-          "type": "number",
-          "attr": {
-            "min": 0,
-            "max": 7200
-          },
-          "value": 600,
-          "label": {
-            "en": "Poll interval measure (W)",
-            "nl": "Poll interval measure (W)"
-          },
-          "hint": {
-            "en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
-            "nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
-          }
-        },
-        {
-          "id": "poll_interval_meter",
-          "type": "number",
-          "attr": {
-            "min": 0,
-            "max": 7200
-          },
-          "value": 3600,
-          "label": {
-            "en": "Poll interval meter (kWh)",
-            "nl": "Poll interval meter (kWh)"
-          },
-          "hint": {
-            "en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
-            "nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
-          }
-        }
-      ]
-    },
-    {
-      "id": "powernode-6",
-      "name": {
-        "en": "Greenwave PowerNode 6",
-        "nl": "Greenwave PowerNode 6"
-      },
-      "icon": "/drivers/powernode-6/assets/icon.svg",
-      "images": {
-        "large": "/drivers/powernode-6/assets/images/large.jpg",
-        "small": "/drivers/powernode-6/assets/images/small.jpg"
-      },
-      "class": "socket",
-      "capabilities": [
-        "onoff",
-        "measure_power",
-        "meter_power"
-      ],
-      "zwave": {
-        "manufacturerId": 153,
-        "productTypeId": 3,
-        "productId": 4,
-        "learnmode": {
-          "image": "/drivers/powernode-6/assets/learnmode.svg",
-          "instruction": {
-            "en": "Press the small button on your Greenwave PowerNode",
-            "nl": "Druk op de kleine knop op de Greenwave PowerNode"
-          }
-        },
-        "associationGroups": [
-          1,
-          3
-        ],
-        "associationGroupsOptions": {
-          "1": {
-            "hint": {
-              "en": "Reports the device status and allows control (ON/OFF) over the powernode (Homey ID by default). It is not recommended to change this group.",
-              "nl": "Rapportage van de status van de powernode en staat controle (AAN/UIT) over de powernode toe (Homey ID als standaard waarde). Het is niet aanbevolen om deze groep aan te passen."
-            }
-          },
-          "2": {
-            "hint": {
-              "en": "Reports alarm report when detecting current leakage of defined relay device if an association relationship has been defined (add Z-wave ID of relay device).",
-              "nl": "Rapportage van een alarm op het moment dat een lekstroom gedetecteerd wordt op een gekoppelds apparaat indien een relatie gedefineerd is (voeg het Z-wave ID van het te koppelen apparaat toe)."
-            }
-          },
-          "3": {
-            "hint": {
-              "en": "Reports the power value change if the difference of the instant power reading compared to previous report is larger than the -Power change for update- parameter set (e.g. 80%). (Homey ID by default)",
-              "nl": "Rapportage van de gebruikte energie wanneer het verschil met de vorige rapportage groter is dan de waarde ingesteld bij -Wijziging in energie voor update- parameter (bv. 80%). (Homey ID als standaard waarde)"
-            }
-          },
-          "4": {
-            "hint": {
-              "en": "Reports alarm when the powernode is in over-current protection and powers off a relay device if an association relationship has been defined (add Z-wave ID of relay device).",
-              "nl": "Alarm reportage wanneer de powernode in over-current protectie overschakeld en automatische uitschakeling van het gekoppelde apparaat indien een relatie gedefineerd is (voeg het Z-wave ID van het te koppelen apparaat toe)."
-            }
-          }
-        },
-        "defaultConfiguration": [
-          {
-            "id": 0,
-            "size": 1,
-            "value": 80
-          },
-          {
-            "id": 1,
-            "size": 1,
-            "value": "0xFF"
-          }
-        ],
-        "multiChannelNodes": {
-          "1": {
-            "class": "socket",
-            "capabilities": [
-              "onoff",
-              "measure_power",
-              "meter_power"
-            ],
-            "icon": "/drivers/powernode-6/assets/icon-1.svg",
-            "name": {
-              "en": "Greenwave PowerNode Socket 1",
-              "nl": "Greenwave PowerNode Stopcontact 1"
-            }
-          },
-          "2": {
-            "class": "socket",
-            "capabilities": [
-              "onoff",
-              "measure_power",
-              "meter_power"
-            ],
-            "icon": "/drivers/powernode-6/assets/icon-2.svg",
-            "name": {
-              "en": "Greenwave PowerNode Socket 2",
-              "nl": "Greenwave PowerNode Stopcontact 2"
-            }
-          },
-          "3": {
-            "class": "socket",
-            "capabilities": [
-              "onoff",
-              "measure_power",
-              "meter_power"
-            ],
-            "icon": "/drivers/powernode-6/assets/icon-3.svg",
-            "name": {
-              "en": "Greenwave PowerNode Socket 3",
-              "nl": "Greenwave PowerNode Stopcontact 3"
-            }
-          },
-          "4": {
-            "class": "socket",
-            "capabilities": [
-              "onoff",
-              "measure_power",
-              "meter_power"
-            ],
-            "icon": "/drivers/powernode-6/assets/icon-4.svg",
-            "name": {
-              "en": "Greenwave PowerNode Socket 4",
-              "nl": "Greenwave PowerNode Stopcontact 4"
-            }
-          },
-          "5": {
-            "class": "socket",
-            "capabilities": [
-              "onoff",
-              "measure_power",
-              "meter_power"
-            ],
-            "icon": "/drivers/powernode-6/assets/icon-5.svg",
-            "name": {
-              "en": "Greenwave PowerNode Socket 5",
-              "nl": "Greenwave PowerNode Stopcontact 5"
-            }
-          },
-          "6": {
-            "class": "socket",
-            "capabilities": [
-              "onoff",
-              "measure_power",
-              "meter_power"
-            ],
-            "icon": "/drivers/powernode-6/assets/icon-6.svg",
-            "name": {
-              "en": "Greenwave PowerNode Socket 6",
-              "nl": "Greenwave PowerNode Stopcontact 6"
-            }
-          }
-        }
-      },
-      "settings": [
-        {
-          "id": 0,
-          "type": "number",
-          "attr": {
-            "min": 1,
-            "max": 100
-          },
-          "value": 80,
-          "label": {
-            "en": "Power change for update",
-            "nl": "Wijziging in energie voor update"
-          },
-          "hint": {
-            "en": "Power change required to send an update to controller, in % from 1 to 100, default: 80 [%].",
-            "nl": "Wijziging in energie voordat er een update naar de controller wordt gestuurd, in % van 1 tot 100, standaard: 80 [%].."
-          }
-        },
-        {
-          "id": 1,
-          "type": "number",
-          "attr": {
-            "min": 1,
-            "max": 255
-          },
-          "value": 255,
-          "label": {
-            "en": "Keep alive time",
-            "nl": "Keep alive time"
-          },
-          "hint": {
-            "en": "The amount of minutes without contact between controller and device before the device starts blinking green, default: 255 [min].",
-            "nl": "Aantal minuten zonder contact tussen controller en apparaat voordat het apparaat groen gaat knipperen, standaard: 255 [min]."
-          }
-        },
-    		{
-    			"type": "group",
-    			"label": {
-    				"en": "Poll State socket 1",
-    				"nl": "Poll Status stopcontact 1"
-    			},
-    			"collapsed": true,
-    			"children": [
-    				{
-    					"id": "poll_onoff_1",
-    					"type": "number",
-    					"attr": {
-    						"min": 0,
-    						"max": 7200
-    					},
-    					"value": 300,
-    					"label": {
-    						"en": "On/off",
-    						"nl": "Aan/uit"
-    					},
-    					"hint": {
-    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
-    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
-    					}
-    				},
-    				{
-    					"id": "poll_measure_1",
-    					"type": "number",
-    					"attr": {
-    						"min": 0,
-    						"max": 7200
-    					},
-    					"value": 600,
-    					"label": {
-    						"en": "Wattage",
-    						"nl": "Wattage"
-    					},
-    					"hint": {
-    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
-    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
-    					}
-    				},
-    				{
-    					"id": "poll_meter_1",
-    					"type": "number",
-    					"attr": {
-    						"min": 0,
-    						"max": 7200
-    					},
-    					"value": 3600,
-    					"label": {
-    						"en": "KiloWattHour (kWh)",
-    						"nl": "KiloWattUur (kWh)"
-    					},
-    					"hint": {
-    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
-    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
-    					}
-    				}
-    			]
-    		},
-    		{
-    			"type": "group",
-    			"label": {
-    				"en": "Poll state socket 2",
-    				"nl": "Poll status stopcontact 2"
-    			},
-    			"collapsed": true,
-    			"children": [
-    				{
-    					"id": "poll_onoff_2",
-    					"type": "number",
-    					"attr": {
-    						"min": 0,
-    						"max": 7200
-    					},
-    					"value": 300,
-    					"label": {
-    						"en": "On/off",
-    						"nl": "Aan/uit"
-    					},
-    					"hint": {
-    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
-    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
-    					}
-    				},
-    				{
-    					"id": "poll_measure_2",
-    					"type": "number",
-    					"attr": {
-    						"min": 0,
-    						"max": 7200
-    					},
-    					"value": 600,
-    					"label": {
-    						"en": "Wattage",
-    						"nl": "Wattage"
-    					},
-    					"hint": {
-    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
-    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
-    					}
-    				},
-    				{
-    					"id": "poll_meter_2",
-    					"type": "number",
-    					"attr": {
-    						"min": 0,
-    						"max": 7200
-    					},
-    					"value": 3600,
-    					"label": {
-    						"en": "KiloWattHour (kWh)",
-    						"nl": "KiloWattUur (kWh)"
-    					},
-    					"hint": {
-    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
-    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
-    					}
-    				}
-    			]
-    		},
-    		{
-    			"type": "group",
-    			"label": {
-    				"en": "Poll state socket 3",
-    				"nl": "Poll status stopcontact 3"
-    			},
-    			"collapsed": true,
-    			"children": [
-    				{
-    					"id": "poll_onoff_3",
-    					"type": "number",
-    					"attr": {
-    						"min": 0,
-    						"max": 7200
-    					},
-    					"value": 300,
-    					"label": {
-    						"en": "On/off",
-    						"nl": "Aan/uit"
-    					},
-    					"hint": {
-    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
-    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
-    					}
-    				},
-    				{
-    					"id": "poll_measure_3",
-    					"type": "number",
-    					"attr": {
-    						"min": 0,
-    						"max": 7200
-    					},
-    					"value": 600,
-    					"label": {
-    						"en": "Wattage",
-    						"nl": "Wattage"
-    					},
-    					"hint": {
-    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
-    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
-    					}
-    				},
-    				{
-    					"id": "poll_meter_3",
-    					"type": "number",
-    					"attr": {
-    						"min": 0,
-    						"max": 7200
-    					},
-    					"value": 3600,
-    					"label": {
-    						"en": "KiloWattHour (kWh)",
-    						"nl": "KiloWattUur (kWh)"
-    					},
-    					"hint": {
-    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
-    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
-    					}
-    				}
-    			]
-    		},
-    		{
-    			"type": "group",
-    			"label": {
-    				"en": "Poll state socket 4",
-    				"nl": "Poll status stopcontact 4"
-    			},
-    			"collapsed": true,
-    			"children": [
-    				{
-    					"id": "poll_onoff_4",
-    					"type": "number",
-    					"attr": {
-    						"min": 0,
-    						"max": 7200
-    					},
-    					"value": 30,
-    					"label": {
-    						"en": "On/off",
-    						"nl": "Aan/uit"
-    					},
-    					"hint": {
-    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
-    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
-    					}
-    				},
-    				{
-    					"id": "poll_measure_4",
-    					"type": "number",
-    					"attr": {
-    						"min": 0,
-    						"max": 7200
-    					},
-    					"value": 600,
-    					"label": {
-    						"en": "Wattage",
-    						"nl": "Wattage"
-    					},
-    					"hint": {
-    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
-    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
-    					}
-    				},
-    				{
-    					"id": "poll_meter_4",
-    					"type": "number",
-    					"attr": {
-    						"min": 0,
-    						"max": 7200
-    					},
-    					"value": 3600,
-    					"label": {
-    						"en": "KiloWattHour (kWh)",
-    						"nl": "KiloWattUur (kWh)"
-    					},
-    					"hint": {
-    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
-    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
-    					}
-    				}
-    			]
-    		},
-    		{
-    			"type": "group",
-    			"label": {
-    				"en": "Poll state socket 5",
-    				"nl": "Poll status stopcontact 5"
-    			},
-    			"collapsed": true,
-    			"children": [
-    				{
-    					"id": "poll_onoff_5",
-    					"type": "number",
-    					"attr": {
-    						"min": 0,
-    						"max": 7200
-    					},
-    					"value": 300,
-    					"label": {
-    						"en": "On/off",
-    						"nl": "Aan/uit"
-    					},
-    					"hint": {
-    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
-    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
-    					}
-    				},
-    				{
-    					"id": "poll_measure_5",
-    					"type": "number",
-    					"attr": {
-    						"min": 0,
-    						"max": 7200
-    					},
-    					"value": 600,
-    					"label": {
-    						"en": "Wattage",
-    						"nl": "Wattage"
-    					},
-    					"hint": {
-    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
-    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
-    					}
-    				},
-    				{
-    					"id": "poll_meter_5",
-    					"type": "number",
-    					"attr": {
-    						"min": 0,
-    						"max": 7200
-    					},
-    					"value": 3600,
-    					"label": {
-    						"en": "KiloWattHour (kWh)",
-    						"nl": "KiloWattUur (kWh)"
-    					},
-    					"hint": {
-    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
-    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
-    					}
-    				}
-    			]
-    		},
-    		{
-    			"type": "group",
-    			"label": {
-    				"en": "Poll state socket 6",
-    				"nl": "Poll status stopcontact 6"
-    			},
-    			"collapsed": true,
-    			"children": [
-    				{
-    					"id": "poll_onoff_6",
-    					"type": "number",
-    					"attr": {
-    						"min": 0,
-    						"max": 7200
-    					},
-    					"value": 300,
-    					"label": {
-    						"en": "On/off",
-    						"nl": "Aan/uit"
-    					},
-    					"hint": {
-    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
-    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
-    					}
-    				},
-    				{
-    					"id": "poll_measure_6",
-    					"type": "number",
-    					"attr": {
-    						"min": 0,
-    						"max": 7200
-    					},
-    					"value": 600,
-    					"label": {
-    						"en": "Wattage",
-    						"nl": "Wattage"
-    					},
-    					"hint": {
-    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
-    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
-    					}
-    				},
-    				{
-    					"id": "poll_meter_6",
-    					"type": "number",
-    					"attr": {
-    						"min": 0,
-    						"max": 7200
-    					},
-    					"value": 3600,
-    					"label": {
-    						"en": "KiloWattHour (kWh)",
-    						"nl": "KiloWattUur (kWh)"
-    					},
-    					"hint": {
-    						"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
-    						"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
-    					}
-    				}
-    			]
-    		}
-      ]
-    }
-  ]
+	"id": "com.greenwavesystems",
+	"name": {
+		"en": "Greenwave Systems",
+		"nl": "Greenwave Systems"
+	},
+	"version": "1.1.2",
+	"compatibility": ">=1.0.5",
+	"author": {
+		"name": "Athom B.V.",
+		"email": "info@athom.com"
+	},
+	"contributors": {
+		"developers": [
+			{
+				"name": "Rex Markesteijn",
+				"email": "rmarkesteijn79@gmail.com"
+			},
+			{
+				"name": "Jelger Haanstra",
+				"email": "homey@solidewebservices.com"
+			},
+			{
+				"name": "Ted Tolboom",
+				"email": "dTNL.Homey@gmail.com"
+			}
+		]
+	},
+	"flow": {
+		"actions": [
+			{
+				"id": "PN1_reset_meter",
+				"title": {
+					"en": "Reset meter values",
+					"nl": "Meter waarden resetten"
+				},
+				"hint": {
+					"en": "Reset the accumulated power usage (kWh). Can not be reversed.",
+					"nl": "Reset de stroomverbruik (kWh) waarden. Kan niet ongedaan worden gemaakt."
+				},
+				"args": [
+					{
+						"name": "device",
+						"type": "device",
+						"filter": "driver_id=powernode-1"
+					}
+				]
+			},
+			{
+				"id": "PN6_reset_meter",
+				"title": {
+					"en": "Reset meter values",
+					"nl": "Meter waarden resetten"
+				},
+				"hint": {
+					"en": "Reset the accumulated power usage (kWh). Can not be reversed.",
+					"nl": "Reset de stroomverbruik (kWh) waarden. Kan niet ongedaan worden gemaakt."
+				},
+				"args": [
+					{
+						"name": "device",
+						"type": "device",
+						"filter": "driver_id=powernode-6"
+					}
+				]
+			}
+		]
+	},
+	"category": [
+		"appliances"
+	],
+	"description": {
+		"en": "Drivers for Greenwave Systems devices",
+		"nl": "Drivers voor Greenwave Systems apparaten"
+	},
+	"images": {
+		"large": "/assets/images/large.jpg",
+		"small": "/assets/images/small.jpg"
+	},
+	"drivers": [
+		{
+			"id": "powernode-1",
+			"name": {
+				"en": "Greenwave PowerNode 1",
+				"nl": "Greenwave PowerNode 1"
+			},
+			"icon": "/drivers/powernode-1/assets/icon.svg",
+			"images": {
+				"large": "/drivers/powernode-1/assets/images/large.jpg",
+				"small": "/drivers/powernode-1/assets/images/small.jpg"
+			},
+			"class": "socket",
+			"capabilities": [
+				"onoff",
+				"measure_power",
+				"meter_power"
+			],
+			"zwave": {
+				"manufacturerId": 153,
+				"productTypeId": 2,
+				"productId": 2,
+				"learnmode": {
+					"image": "/drivers/powernode-1/assets/learnmode.svg",
+					"instruction": {
+						"en": "Press the small button on your Greenwave PowerNode",
+						"nl": "Druk op de kleine knop op de Greenwave PowerNode"
+					}
+				},
+				"associationGroups": [
+					1,
+					3
+				],
+				"associationGroupsOptions": {
+					"1": {
+						"hint": {
+							"en": "Reports the device status and allows control (ON/OFF) over the powernode (Homey ID by default). It is not recommended to change this group.",
+							"nl": "Rapportage van de status van de powernode en staat controle (AAN/UIT) over de powernode toe (Homey ID als standaard waarde). Het is niet aanbevolen om deze groep aan te passen."
+						}
+					},
+					"2": {
+						"hint": {
+							"en": "Reports alarm report when detecting current leakage of defined relay device if an association relationship has been defined (add Z-wave ID of relay device).",
+							"nl": "Rapportage van een alarm op het moment dat een lekstroom gedetecteerd wordt op een gekoppelds apparaat indien een relatie gedefineerd is (voeg het Z-wave ID van het te koppelen apparaat toe)."
+						}
+					},
+					"3": {
+						"hint": {
+							"en": "Reports the power value change if the difference of the instant power reading compared to previous report is larger than the -Power change for update- parameter set (e.g. 80%). (Homey ID by default)",
+							"nl": "Rapportage van de gebruikte energie wanneer het verschil met de vorige rapportage groter is dan de waarde ingesteld bij -Wijziging in energie voor update- parameter (bv. 80%). (Homey ID als standaard waarde)"
+						}
+					},
+					"4": {
+						"hint": {
+							"en": "Reports alarm when the powernode is in over-current protection and powers off a relay device if an association relationship has been defined (add Z-wave ID of relay device).",
+							"nl": "Alarm reportage wanneer de powernode in over-current protectie overschakeld en automatische uitschakeling van het gekoppelde apparaat indien een relatie gedefineerd is (voeg het Z-wave ID van het te koppelen apparaat toe)."
+						}
+					}
+				},
+				"defaultConfiguration": [
+					{
+						"id": 0,
+						"size": 1,
+						"value": 80
+					},
+					{
+						"id": 1,
+						"size": 1,
+						"value": "0xFF"
+					}
+				]
+			},
+			"settings": [
+				{
+					"id": 0,
+					"type": "number",
+					"attr": {
+						"min": 1,
+						"max": 100
+					},
+					"value": 80,
+					"label": {
+						"en": "Power change for update",
+						"nl": "Wijziging in energie voor update"
+					},
+					"hint": {
+						"en": "Power change required to send an update to controller, in % from 1 to 100, default: 80 [%].",
+						"nl": "Wijziging in energie voordat er een update naar de controller wordt gestuurd, in % van 1 tot 100, standaard: 80 [%].."
+					}
+				},
+				{
+					"id": 1,
+					"type": "number",
+					"attr": {
+						"min": 1,
+						"max": 255
+					},
+					"value": 255,
+					"label": {
+						"en": "Keep alive time",
+						"nl": "Keep alive time"
+					},
+					"hint": {
+						"en": "The amount of minutes without contact between controller and device before the device starts blinking green, default: 255 [min].",
+						"nl": "Aantal minuten zonder contact tussen controller en apparaat voordat het apparaat groen gaat knipperen, standaard: 255 [min]."
+					}
+				},
+				{
+					"type": "group",
+					"label": {
+						"en": "Poll interval",
+						"nl": "Poll interal"
+					},
+					"children": [
+						{
+							"id": "poll_interval_onoff",
+							"type": "number",
+							"attr": {
+								"min": 0,
+								"max": 7200
+							},
+							"value": 0,
+							"label": {
+								"en": "Poll interval on/off",
+								"nl": "Poll interval on/off"
+							},
+							"hint": {
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
+							}
+						},
+						{
+							"id": "poll_interval_measure",
+							"type": "number",
+							"attr": {
+								"min": 0,
+								"max": 7200
+							},
+							"value": 600,
+							"label": {
+								"en": "Poll interval measure (W)",
+								"nl": "Poll interval measure (W)"
+							},
+							"hint": {
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
+							}
+						},
+						{
+							"id": "poll_interval_meter",
+							"type": "number",
+							"attr": {
+								"min": 0,
+								"max": 7200
+							},
+							"value": 3600,
+							"label": {
+								"en": "Poll interval meter (kWh)",
+								"nl": "Poll interval meter (kWh)"
+							},
+							"hint": {
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
+							}
+						}
+					]
+				}
+			]
+		},
+		{
+			"id": "powernode-6",
+			"name": {
+				"en": "Greenwave PowerNode 6",
+				"nl": "Greenwave PowerNode 6"
+			},
+			"icon": "/drivers/powernode-6/assets/icon.svg",
+			"images": {
+				"large": "/drivers/powernode-6/assets/images/large.jpg",
+				"small": "/drivers/powernode-6/assets/images/small.jpg"
+			},
+			"class": "socket",
+			"capabilities": [
+				"onoff",
+				"measure_power",
+				"meter_power"
+			],
+			"zwave": {
+				"manufacturerId": 153,
+				"productTypeId": 3,
+				"productId": 4,
+				"learnmode": {
+					"image": "/drivers/powernode-6/assets/learnmode.svg",
+					"instruction": {
+						"en": "Press the small button on your Greenwave PowerNode",
+						"nl": "Druk op de kleine knop op de Greenwave PowerNode"
+					}
+				},
+				"associationGroups": [
+					1,
+					3
+				],
+				"associationGroupsOptions": {
+					"1": {
+						"hint": {
+							"en": "Reports the device status and allows control (ON/OFF) over the powernode (Homey ID by default). It is not recommended to change this group.",
+							"nl": "Rapportage van de status van de powernode en staat controle (AAN/UIT) over de powernode toe (Homey ID als standaard waarde). Het is niet aanbevolen om deze groep aan te passen."
+						}
+					},
+					"2": {
+						"hint": {
+							"en": "Reports alarm report when detecting current leakage of defined relay device if an association relationship has been defined (add Z-wave ID of relay device).",
+							"nl": "Rapportage van een alarm op het moment dat een lekstroom gedetecteerd wordt op een gekoppelds apparaat indien een relatie gedefineerd is (voeg het Z-wave ID van het te koppelen apparaat toe)."
+						}
+					},
+					"3": {
+						"hint": {
+							"en": "Reports the power value change if the difference of the instant power reading compared to previous report is larger than the -Power change for update- parameter set (e.g. 80%). (Homey ID by default)",
+							"nl": "Rapportage van de gebruikte energie wanneer het verschil met de vorige rapportage groter is dan de waarde ingesteld bij -Wijziging in energie voor update- parameter (bv. 80%). (Homey ID als standaard waarde)"
+						}
+					},
+					"4": {
+						"hint": {
+							"en": "Reports alarm when the powernode is in over-current protection and powers off a relay device if an association relationship has been defined (add Z-wave ID of relay device).",
+							"nl": "Alarm reportage wanneer de powernode in over-current protectie overschakeld en automatische uitschakeling van het gekoppelde apparaat indien een relatie gedefineerd is (voeg het Z-wave ID van het te koppelen apparaat toe)."
+						}
+					}
+				},
+				"defaultConfiguration": [
+					{
+						"id": 0,
+						"size": 1,
+						"value": 80
+					},
+					{
+						"id": 1,
+						"size": 1,
+						"value": "0xFF"
+					}
+				],
+				"multiChannelNodes": {
+					"1": {
+						"class": "socket",
+						"capabilities": [
+							"onoff",
+							"measure_power",
+							"meter_power"
+						],
+						"icon": "/drivers/powernode-6/assets/icon-1.svg",
+						"name": {
+							"en": "Greenwave PowerNode Socket 1",
+							"nl": "Greenwave PowerNode Stopcontact 1"
+						}
+					},
+					"2": {
+						"class": "socket",
+						"capabilities": [
+							"onoff",
+							"measure_power",
+							"meter_power"
+						],
+						"icon": "/drivers/powernode-6/assets/icon-2.svg",
+						"name": {
+							"en": "Greenwave PowerNode Socket 2",
+							"nl": "Greenwave PowerNode Stopcontact 2"
+						}
+					},
+					"3": {
+						"class": "socket",
+						"capabilities": [
+							"onoff",
+							"measure_power",
+							"meter_power"
+						],
+						"icon": "/drivers/powernode-6/assets/icon-3.svg",
+						"name": {
+							"en": "Greenwave PowerNode Socket 3",
+							"nl": "Greenwave PowerNode Stopcontact 3"
+						}
+					},
+					"4": {
+						"class": "socket",
+						"capabilities": [
+							"onoff",
+							"measure_power",
+							"meter_power"
+						],
+						"icon": "/drivers/powernode-6/assets/icon-4.svg",
+						"name": {
+							"en": "Greenwave PowerNode Socket 4",
+							"nl": "Greenwave PowerNode Stopcontact 4"
+						}
+					},
+					"5": {
+						"class": "socket",
+						"capabilities": [
+							"onoff",
+							"measure_power",
+							"meter_power"
+						],
+						"icon": "/drivers/powernode-6/assets/icon-5.svg",
+						"name": {
+							"en": "Greenwave PowerNode Socket 5",
+							"nl": "Greenwave PowerNode Stopcontact 5"
+						}
+					},
+					"6": {
+						"class": "socket",
+						"capabilities": [
+							"onoff",
+							"measure_power",
+							"meter_power"
+						],
+						"icon": "/drivers/powernode-6/assets/icon-6.svg",
+						"name": {
+							"en": "Greenwave PowerNode Socket 6",
+							"nl": "Greenwave PowerNode Stopcontact 6"
+						}
+					}
+				}
+			},
+			"settings": [
+				{
+					"id": 0,
+					"type": "number",
+					"attr": {
+						"min": 1,
+						"max": 100
+					},
+					"value": 80,
+					"label": {
+						"en": "Power change for update",
+						"nl": "Wijziging in energie voor update"
+					},
+					"hint": {
+						"en": "Power change required to send an update to controller, in % from 1 to 100, default: 80 [%].",
+						"nl": "Wijziging in energie voordat er een update naar de controller wordt gestuurd, in % van 1 tot 100, standaard: 80 [%].."
+					}
+				},
+				{
+					"id": 1,
+					"type": "number",
+					"attr": {
+						"min": 1,
+						"max": 255
+					},
+					"value": 255,
+					"label": {
+						"en": "Keep alive time",
+						"nl": "Keep alive time"
+					},
+					"hint": {
+						"en": "The amount of minutes without contact between controller and device before the device starts blinking green, default: 255 [min].",
+						"nl": "Aantal minuten zonder contact tussen controller en apparaat voordat het apparaat groen gaat knipperen, standaard: 255 [min]."
+					}
+				},
+				{
+					"type": "group",
+					"label": {
+						"en": "Poll interval main socket",
+						"nl": "Poll interal stekkerdoos"
+					},
+					"children": [
+						{
+							"id": "poll_interval_onoff",
+							"type": "number",
+							"attr": {
+								"min": 0,
+								"max": 7200
+							},
+							"value": 0,
+							"label": {
+								"en": "On/off",
+								"nl": "Aan/uit"
+							},
+							"hint": {
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
+							}
+						},
+						{
+							"id": "poll_interval_measure",
+							"type": "number",
+							"attr": {
+								"min": 0,
+								"max": 7200
+							},
+							"value": 600,
+							"label": {
+								"en": "Power (W)",
+								"nl": "Vermogen (W)"
+							},
+							"hint": {
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
+							}
+						},
+						{
+							"id": "poll_interval_meter",
+							"type": "number",
+							"attr": {
+								"min": 0,
+								"max": 7200
+							},
+							"value": 3600,
+							"label": {
+								"en": "Energy consumption (kWh)",
+								"nl": "Energieverbruik (kWh)"
+							},
+							"hint": {
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
+							}
+						}
+					]
+				},
+				{
+					"type": "group",
+					"label": {
+						"en": "Poll State socket 1",
+						"nl": "Poll Status stopcontact 1"
+					},
+					"collapsed": true,
+					"children": [
+						{
+							"id": "endpoint_interval_onoff_1",
+							"type": "number",
+							"attr": {
+								"min": 0,
+								"max": 7200
+							},
+							"value": 0,
+							"label": {
+								"en": "On/off",
+								"nl": "Aan/uit"
+							},
+							"hint": {
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
+							}
+						},
+						{
+							"id": "endpoint_interval_measure_1",
+							"type": "number",
+							"attr": {
+								"min": 0,
+								"max": 7200
+							},
+							"value": 600,
+							"label": {
+								"en": "Wattage",
+								"nl": "Wattage"
+							},
+							"hint": {
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
+							}
+						},
+						{
+							"id": "endpoint_interval_meter_1",
+							"type": "number",
+							"attr": {
+								"min": 0,
+								"max": 7200
+							},
+							"value": 3600,
+							"label": {
+								"en": "KiloWattHour (kWh)",
+								"nl": "KiloWattUur (kWh)"
+							},
+							"hint": {
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
+							}
+						}
+					]
+				},
+				{
+					"type": "group",
+					"label": {
+						"en": "Poll state socket 2",
+						"nl": "Poll status stopcontact 2"
+					},
+					"collapsed": true,
+					"children": [
+						{
+							"id": "endpoint_interval_onoff_2",
+							"type": "number",
+							"attr": {
+								"min": 0,
+								"max": 7200
+							},
+							"value": 0,
+							"label": {
+								"en": "On/off",
+								"nl": "Aan/uit"
+							},
+							"hint": {
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
+							}
+						},
+						{
+							"id": "endpoint_interval_measure_2",
+							"type": "number",
+							"attr": {
+								"min": 0,
+								"max": 7200
+							},
+							"value": 600,
+							"label": {
+								"en": "Wattage",
+								"nl": "Wattage"
+							},
+							"hint": {
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
+							}
+						},
+						{
+							"id": "endpoint_interval_meter_2",
+							"type": "number",
+							"attr": {
+								"min": 0,
+								"max": 7200
+							},
+							"value": 3600,
+							"label": {
+								"en": "KiloWattHour (kWh)",
+								"nl": "KiloWattUur (kWh)"
+							},
+							"hint": {
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
+							}
+						}
+					]
+				},
+				{
+					"type": "group",
+					"label": {
+						"en": "Poll state socket 3",
+						"nl": "Poll status stopcontact 3"
+					},
+					"collapsed": true,
+					"children": [
+						{
+							"id": "endpoint_interval_onoff_3",
+							"type": "number",
+							"attr": {
+								"min": 0,
+								"max": 7200
+							},
+							"value": 0,
+							"label": {
+								"en": "On/off",
+								"nl": "Aan/uit"
+							},
+							"hint": {
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
+							}
+						},
+						{
+							"id": "endpoint_interval_measure_3",
+							"type": "number",
+							"attr": {
+								"min": 0,
+								"max": 7200
+							},
+							"value": 600,
+							"label": {
+								"en": "Wattage",
+								"nl": "Wattage"
+							},
+							"hint": {
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
+							}
+						},
+						{
+							"id": "endpoint_interval_meter_3",
+							"type": "number",
+							"attr": {
+								"min": 0,
+								"max": 7200
+							},
+							"value": 3600,
+							"label": {
+								"en": "KiloWattHour (kWh)",
+								"nl": "KiloWattUur (kWh)"
+							},
+							"hint": {
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
+							}
+						}
+					]
+				},
+				{
+					"type": "group",
+					"label": {
+						"en": "Poll state socket 4",
+						"nl": "Poll status stopcontact 4"
+					},
+					"collapsed": true,
+					"children": [
+						{
+							"id": "endpoint_interval_onoff_4",
+							"type": "number",
+							"attr": {
+								"min": 0,
+								"max": 7200
+							},
+							"value": 0,
+							"label": {
+								"en": "On/off",
+								"nl": "Aan/uit"
+							},
+							"hint": {
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
+							}
+						},
+						{
+							"id": "endpoint_interval_measure_4",
+							"type": "number",
+							"attr": {
+								"min": 0,
+								"max": 7200
+							},
+							"value": 600,
+							"label": {
+								"en": "Wattage",
+								"nl": "Wattage"
+							},
+							"hint": {
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
+							}
+						},
+						{
+							"id": "endpoint_interval_meter_4",
+							"type": "number",
+							"attr": {
+								"min": 0,
+								"max": 7200
+							},
+							"value": 3600,
+							"label": {
+								"en": "KiloWattHour (kWh)",
+								"nl": "KiloWattUur (kWh)"
+							},
+							"hint": {
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
+							}
+						}
+					]
+				},
+				{
+					"type": "group",
+					"label": {
+						"en": "Poll state socket 5",
+						"nl": "Poll status stopcontact 5"
+					},
+					"collapsed": true,
+					"children": [
+						{
+							"id": "endpoint_interval_onoff_5",
+							"type": "number",
+							"attr": {
+								"min": 0,
+								"max": 7200
+							},
+							"value": 0,
+							"label": {
+								"en": "On/off",
+								"nl": "Aan/uit"
+							},
+							"hint": {
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
+							}
+						},
+						{
+							"id": "endpoint_interval_measure_5",
+							"type": "number",
+							"attr": {
+								"min": 0,
+								"max": 7200
+							},
+							"value": 600,
+							"label": {
+								"en": "Wattage",
+								"nl": "Wattage"
+							},
+							"hint": {
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
+							}
+						},
+						{
+							"id": "endpoint_interval_meter_5",
+							"type": "number",
+							"attr": {
+								"min": 0,
+								"max": 7200
+							},
+							"value": 3600,
+							"label": {
+								"en": "KiloWattHour (kWh)",
+								"nl": "KiloWattUur (kWh)"
+							},
+							"hint": {
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
+							}
+						}
+					]
+				},
+				{
+					"type": "group",
+					"label": {
+						"en": "Poll state socket 6",
+						"nl": "Poll status stopcontact 6"
+					},
+					"collapsed": true,
+					"children": [
+						{
+							"id": "endpoint_interval_onoff_6",
+							"type": "number",
+							"attr": {
+								"min": 0,
+								"max": 7200
+							},
+							"value": 0,
+							"label": {
+								"en": "On/off",
+								"nl": "Aan/uit"
+							},
+							"hint": {
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 300 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 300 seconden."
+							}
+						},
+						{
+							"id": "endpoint_interval_measure_6",
+							"type": "number",
+							"attr": {
+								"min": 0,
+								"max": 7200
+							},
+							"value": 600,
+							"label": {
+								"en": "Wattage",
+								"nl": "Wattage"
+							},
+							"hint": {
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 600 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 600 seconden."
+							}
+						},
+						{
+							"id": "endpoint_interval_meter_6",
+							"type": "number",
+							"attr": {
+								"min": 0,
+								"max": 7200
+							},
+							"value": 3600,
+							"label": {
+								"en": "KiloWattHour (kWh)",
+								"nl": "KiloWattUur (kWh)"
+							},
+							"hint": {
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 7200.\nDefault: 3600 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 7200.\nStandaard waarde: 3600 seconden."
+							}
+						}
+					]
+				}
+			]
+		}
+	]
 }

--- a/app.json
+++ b/app.json
@@ -43,8 +43,8 @@
 						"name": "device",
 						"type": "device",
 						"filter": "driver_id=powernode-1"
-				}
-			]
+					}
+				]
 			},
 			{
 				"id": "PN6_reset_meter",
@@ -61,8 +61,8 @@
 						"name": "device",
 						"type": "device",
 						"filter": "driver_id=powernode-6"
-				}
-			]
+					}
+				]
 			}
 		]
 	},
@@ -200,14 +200,14 @@
 							},
 							"value": 0,
 							"label": {
-								"en": "Poll interval on/off",
-								"nl": "Poll interval on/off"
+								"en": "On/off",
+								"nl": "On/off"
 							},
 							"hint": {
 								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 300 seconds.",
 								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 300 seconden."
 							}
-					},
+						},
 						{
 							"id": "poll_interval_measure",
 							"type": "number",
@@ -215,16 +215,16 @@
 								"min": 0,
 								"max": 86400
 							},
-							"value": 900,
+							"value": 600,
 							"label": {
-								"en": "Poll interval measure (W)",
-								"nl": "Poll interval measure (W)"
+								"en": "Power (W)",
+								"nl": "Vermogen (W)"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 900 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 900 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 600 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 600 seconden."
 							}
-					},
+						},
 						{
 							"id": "poll_interval_meter",
 							"type": "number",
@@ -234,14 +234,14 @@
 							},
 							"value": 3600,
 							"label": {
-								"en": "Poll interval meter (kWh)",
-								"nl": "Poll interval meter (kWh)"
+								"en": "Energy consumption (kWh)",
+								"nl": "Energieverbruik (kWh)"
 							},
 							"hint": {
 								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 3600 seconds.",
 								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 3600 seconden."
 							}
-					}
+						}
 					]
 			}
 			]
@@ -452,8 +452,8 @@
 								"nl": "Aan/uit"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 300 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 300 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling. (only needed if external switching is used)\nRange: 0 - 86400.\nDefault: 0 seconds. ",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen. (alleen nodig als je extern schakelt)\nBereik: 0 - 86400.\nStandaard waarde: 0 seconden."
 							}
 						},
 						{
@@ -513,8 +513,8 @@
 								"nl": "Aan/uit"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 300 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 300 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling. (only needed if external switching is used)\nRange: 0 - 86400.\nDefault: 0 seconds. ",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen. (alleen nodig als je extern schakelt)\nBereik: 0 - 86400.\nStandaard waarde: 0 seconden."
 							}
 						},
 						{
@@ -526,8 +526,8 @@
 							},
 							"value": 605,
 							"label": {
-								"en": "Wattage",
-								"nl": "Wattage"
+								"en": "Power (W)",
+								"nl": "Vermogen (W)"
 							},
 							"hint": {
 								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 605 seconds.",
@@ -543,8 +543,8 @@
 							},
 							"value": 3605,
 							"label": {
-								"en": "KiloWattHour (kWh)",
-								"nl": "KiloWattUur (kWh)"
+								"en": "Energy consumption (kWh)",
+								"nl": "Energieverbruik (kWh)"
 							},
 							"hint": {
 								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 3605 seconds.",
@@ -574,8 +574,8 @@
 								"nl": "Aan/uit"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 300 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 300 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling. (only needed if external switching is used)\nRange: 0 - 86400.\nDefault: 0 seconds. ",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen. (alleen nodig als je extern schakelt)\nBereik: 0 - 86400.\nStandaard waarde: 0 seconden."
 							}
 						},
 						{
@@ -587,8 +587,8 @@
 							},
 							"value": 610,
 							"label": {
-								"en": "Wattage",
-								"nl": "Wattage"
+								"en": "Power (W)",
+								"nl": "Vermogen (W)"
 							},
 							"hint": {
 								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 610 seconds.",
@@ -604,8 +604,8 @@
 							},
 							"value": 3610,
 							"label": {
-								"en": "KiloWattHour (kWh)",
-								"nl": "KiloWattUur (kWh)"
+								"en": "Energy consumption (kWh)",
+								"nl": "Energieverbruik (kWh)"
 							},
 							"hint": {
 								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 3610 seconds.",
@@ -635,8 +635,8 @@
 								"nl": "Aan/uit"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 300 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 300 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling. (only needed if external switching is used)\nRange: 0 - 86400.\nDefault: 0 seconds. ",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen. (alleen nodig als je extern schakelt)\nBereik: 0 - 86400.\nStandaard waarde: 0 seconden."
 							}
 						},
 						{
@@ -648,8 +648,8 @@
 							},
 							"value": 615,
 							"label": {
-								"en": "Wattage",
-								"nl": "Wattage"
+								"en": "Power (W)",
+								"nl": "Vermogen (W)"
 							},
 							"hint": {
 								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 615 seconds.",
@@ -665,8 +665,8 @@
 							},
 							"value": 3615,
 							"label": {
-								"en": "KiloWattHour (kWh)",
-								"nl": "KiloWattUur (kWh)"
+								"en": "Energy consumption (kWh)",
+								"nl": "Energieverbruik (kWh)"
 							},
 							"hint": {
 								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 3615 seconds.",
@@ -696,8 +696,8 @@
 								"nl": "Aan/uit"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 300 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 300 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling. (only needed if external switching is used)\nRange: 0 - 86400.\nDefault: 0 seconds. ",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen. (alleen nodig als je extern schakelt)\nBereik: 0 - 86400.\nStandaard waarde: 0 seconden."
 							}
 						},
 						{
@@ -709,12 +709,12 @@
 							},
 							"value": 620,
 							"label": {
-								"en": "Wattage",
-								"nl": "Wattage"
+								"en": "Power (W)",
+								"nl": "Vermogen (W)"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault:620 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde:620 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 620 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 620 seconden."
 							}
 						},
 						{
@@ -726,8 +726,8 @@
 							},
 							"value": 3620,
 							"label": {
-								"en": "KiloWattHour (kWh)",
-								"nl": "KiloWattUur (kWh)"
+								"en": "Energy consumption (kWh)",
+								"nl": "Energieverbruik (kWh)"
 							},
 							"hint": {
 								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 3620 seconds.",
@@ -757,8 +757,8 @@
 								"nl": "Aan/uit"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 300 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 300 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling. (only needed if external switching is used)\nRange: 0 - 86400.\nDefault: 0 seconds. ",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen. (alleen nodig als je extern schakelt)\nBereik: 0 - 86400.\nStandaard waarde: 0 seconden."
 							}
 						},
 						{
@@ -770,12 +770,12 @@
 							},
 							"value": 625,
 							"label": {
-								"en": "Wattage",
-								"nl": "Wattage"
+								"en": "Power (W)",
+								"nl": "Vermogen (W)"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault:625 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde:625 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 625 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 625 seconden."
 							}
 						},
 						{
@@ -787,8 +787,8 @@
 							},
 							"value": 3625,
 							"label": {
-								"en": "KiloWattHour (kWh)",
-								"nl": "KiloWattUur (kWh)"
+								"en": "Energy consumption (kWh)",
+								"nl": "Energieverbruik (kWh)"
 							},
 							"hint": {
 								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 3625 seconds.",
@@ -818,8 +818,8 @@
 								"nl": "Aan/uit"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 300 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 300 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling. (only needed if external switching is used)\nRange: 0 - 86400.\nDefault: 0 seconds. ",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen. (alleen nodig als je extern schakelt)\nBereik: 0 - 86400.\nStandaard waarde: 0 seconden."
 							}
 						},
 						{
@@ -831,12 +831,12 @@
 							},
 							"value": 630,
 							"label": {
-								"en": "Wattage",
-								"nl": "Wattage"
+								"en": "Power (W)",
+								"nl": "Vermogen (W)"
 							},
 							"hint": {
-								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault:630 seconds.",
-								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde:630 seconden."
+								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 630 seconds.",
+								"nl": "Aantal seconden tussen het opvragen van een status update aan het apparaat, 0 zal polling uitschakelen.\nBereik: 0 - 86400.\nStandaard waarde: 630 seconden."
 							}
 						},
 						{
@@ -848,8 +848,8 @@
 							},
 							"value": 3630,
 							"label": {
-								"en": "KiloWattHour (kWh)",
-								"nl": "KiloWattUur (kWh)"
+								"en": "Energy consumption (kWh)",
+								"nl": "Energieverbruik (kWh)"
 							},
 							"hint": {
 								"en": "The amount of seconds between asking the device for a status update, 0 will disable polling.\nRange: 0 - 86400.\nDefault: 3630 seconds.",

--- a/app.json
+++ b/app.json
@@ -188,7 +188,7 @@
 					"type": "group",
 					"label": {
 						"en": "Poll interval",
-						"nl": "Poll interal"
+						"nl": "Poll interval"
 					},
 					"children": [
 						{

--- a/app.json
+++ b/app.json
@@ -163,8 +163,8 @@
 						"nl": "Wijziging in energie voor update"
 					},
 					"hint": {
-						"en": "Power change required to send an update to controller, in % from 1 to 100, default: 80 [%].",
-						"nl": "Wijziging in energie voordat er een update naar de controller wordt gestuurd, in % van 1 tot 100, standaard: 80 [%].."
+						"en": "Power change required to send an update to controller, from 1% to 100%, default: 80 [%].",
+						"nl": "Wijziging in energie voordat er een update naar de controller wordt gestuurd, van 1% tot 100%, standaard: 80 [%]."
 					}
 				},
 				{
@@ -411,8 +411,8 @@
 						"nl": "Wijziging in energie voor update"
 					},
 					"hint": {
-						"en": "Power change required to send an update to controller, in % from 1 to 100, default: 80 [%].",
-						"nl": "Wijziging in energie voordat er een update naar de controller wordt gestuurd, in % van 1 tot 100, standaard: 80 [%].."
+						"en": "Power change required to send an update to controller, from 1% to 100%, default: 80 [%].",
+						"nl": "Wijziging in energie voordat er een update naar de controller wordt gestuurd, van 1% tot 100%, standaard: 80 [%]."
 					}
 				},
 				{
@@ -436,7 +436,7 @@
 					"type": "group",
 					"label": {
 						"en": "Poll interval main socket",
-						"nl": "Poll interal stekkerdoos"
+						"nl": "Poll interval stekkerdoos"
 					},
 					"children": [
 						{
@@ -495,8 +495,8 @@
 				{
 					"type": "group",
 					"label": {
-						"en": "Poll State socket 1",
-						"nl": "Poll Status stopcontact 1"
+						"en": "Poll State Socket 1",
+						"nl": "Poll Status Stopcontact 1"
 					},
 					"collapsed": true,
 					"children": [
@@ -556,8 +556,8 @@
 				{
 					"type": "group",
 					"label": {
-						"en": "Poll state socket 2",
-						"nl": "Poll status stopcontact 2"
+						"en": "Poll State Socket 2",
+						"nl": "Poll Status Stopcontact 2"
 					},
 					"collapsed": true,
 					"children": [
@@ -617,8 +617,8 @@
 				{
 					"type": "group",
 					"label": {
-						"en": "Poll state socket 3",
-						"nl": "Poll status stopcontact 3"
+						"en": "Poll State Socket 3",
+						"nl": "Poll Status Stopcontact 3"
 					},
 					"collapsed": true,
 					"children": [
@@ -678,8 +678,8 @@
 				{
 					"type": "group",
 					"label": {
-						"en": "Poll state socket 4",
-						"nl": "Poll status stopcontact 4"
+						"en": "Poll State Socket 4",
+						"nl": "Poll Status Stopcontact 4"
 					},
 					"collapsed": true,
 					"children": [
@@ -739,8 +739,8 @@
 				{
 					"type": "group",
 					"label": {
-						"en": "Poll state socket 5",
-						"nl": "Poll status stopcontact 5"
+						"en": "Poll State Socket 5",
+						"nl": "Poll Status Stopcontact 5"
 					},
 					"collapsed": true,
 					"children": [
@@ -800,8 +800,8 @@
 				{
 					"type": "group",
 					"label": {
-						"en": "Poll state socket 6",
-						"nl": "Poll status stopcontact 6"
+						"en": "Poll State Socket 6",
+						"nl": "Poll Status Stopcontact 6"
 					},
 					"collapsed": true,
 					"children": [

--- a/drivers/powernode-1/driver.js
+++ b/drivers/powernode-1/driver.js
@@ -10,7 +10,6 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 		onoff: {
 			command_class: 'COMMAND_CLASS_SWITCH_BINARY',
 			command_get: 'SWITCH_BINARY_GET',
-			command_get_cb: false,
 			command_set: 'SWITCH_BINARY_SET',
 			command_set_parser: value => ({
 				'Switch Value': value,
@@ -30,7 +29,8 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 			}),
 			command_report: 'METER_REPORT',
 			command_report_parser: report => {
-				if (report.hasOwnProperty('Properties2') &&
+				if (report &&
+					report.hasOwnProperty('Properties2') &&
 					report.Properties2.hasOwnProperty('Scale') &&
 					report.Properties2.Scale === 2) {
 					return report['Meter Value (Parsed)'];
@@ -52,7 +52,8 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 			}),
 			command_report: 'METER_REPORT',
 			command_report_parser: report => {
-				if (report.hasOwnProperty('Properties2') &&
+				if (report &&
+					report.hasOwnProperty('Properties2') &&
 					report.Properties2.hasOwnProperty('Scale') &&
 					report.Properties2.Scale === 0) {
 					return report['Meter Value (Parsed)'];

--- a/drivers/powernode-6/driver.js
+++ b/drivers/powernode-6/driver.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const ZwaveDriver = require('homey-zwavedriver');
+const pollInterval = {};
 
 // http://www.pepper1.net/zwavedb/device/280
 
@@ -17,8 +18,8 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 			}),
 			command_report: 'SWITCH_BINARY_REPORT',
 			command_report_parser: report => report.Value === 'on/enable',
-			pollInterval: 'poll_interval_onoff',
 		},
+
 		measure_power: {
 			command_class: 'COMMAND_CLASS_METER',
 			command_get: 'METER_GET',
@@ -37,7 +38,6 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 				}
 				return null;
 			},
-			pollInterval: 'poll_interval_meter',
 		},
 
 		meter_power: {
@@ -58,9 +58,31 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 				}
 				return null;
 			},
-			pollInterval: 'poll_interval_measure',
 		},
 	},
+
+	beforeInit: (token, callback) => {
+		const node = module.exports.nodes[token];
+		if (node) {
+			module.exports.getSettings(node.device_data, (err, settings) => {
+				if (err) return console.error('error retrieving settings for device', err);
+
+				if (settings.zw_node_id.indexOf('.') < 0 && !pollInterval.hasOwnProperty(token)) {
+					pollInterval[token] = {};
+					for(var i = 1; i <= 6; i++) {
+						pollInterval[token][i] = [];
+						if (settings['poll_onoff_' + i]) setMultiInterval('onoff', i, settings['poll_onoff_' + i], token);
+						if (settings['poll_measure_' + i]) setMultiInterval('measure', i, settings['poll_measure_' + i], token);
+						if (settings['poll_meter_' + i]) setMultiInterval('meter', i, settings['poll_meter_' + i], token);
+					}
+				}
+			});
+		}
+
+		// Initiate the device
+		return callback();
+	},
+
 	settings: {
 		0: {
 			index: 0,
@@ -71,6 +93,24 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 			size: 1,
 			signed: false,
 		},
+		poll_onoff_1: (newValue, oldValue, deviceData) => setMultiInterval('onoff', 1, newValue, deviceData.token),
+		poll_measure_1: (newValue, oldValue, deviceData) => setMultiInterval('measure', 1, newValue, deviceData.token),
+		poll_meter_1: (newValue, oldValue, deviceData) => setMultiInterval('meter', 1, newValue, deviceData.token),
+		poll_onoff_2: (newValue, oldValue, deviceData) => setMultiInterval('onoff', 2, newValue, deviceData.token),
+		poll_measure_2: (newValue, oldValue, deviceData) => setMultiInterval('measure', 2, newValue, deviceData.token),
+		poll_meter_2: (newValue, oldValue, deviceData) => setMultiInterval('meter', 1, newValue, deviceData.token),
+		poll_onoff_3: (newValue, oldValue, deviceData) => setMultiInterval('onoff', 3, newValue, deviceData.token),
+		poll_measure_3: (newValue, oldValue, deviceData) => setMultiInterval('measure', 3, newValue, deviceData.token),
+		poll_meter_3: (newValue, oldValue, deviceData) => setMultiInterval('meter', 3, newValue, deviceData.token),
+		poll_onoff_4: (newValue, oldValue, deviceData) => setMultiInterval('onoff', 4, newValue, deviceData.token),
+		poll_measure_4: (newValue, oldValue, deviceData) => setMultiInterval('measure', 4, newValue, deviceData.token),
+		poll_meter_4: (newValue, oldValue, deviceData) => setMultiInterval('meter', 4, newValue, deviceData.token),
+		poll_onoff_5: (newValue, oldValue, deviceData) => setMultiInterval('onoff', 5, newValue, deviceData.token),
+		poll_measure_5: (newValue, oldValue, deviceData) => setMultiInterval('measure', 5, newValue, deviceData.token),
+		poll_meter_5: (newValue, oldValue, deviceData) => setMultiInterval('meter', 5, newValue, deviceData.token),
+		poll_onoff_6: (newValue, oldValue, deviceData) => setMultiInterval('onoff', 6, newValue, deviceData.token),
+		poll_measure_6: (newValue, oldValue, deviceData) => setMultiInterval('measure', 6, newValue, deviceData.token),
+		poll_meter_6: (newValue, oldValue, deviceData) => setMultiInterval('meter', 6, newValue, deviceData.token),
 	},
 });
 
@@ -87,3 +127,51 @@ Homey.manager('flow').on('action.PN6_reset_meter', (callback, args) => {
 		});
 	} else return callback('unknown_error');
 });
+
+function setMultiInterval (capability, multiChannel, value, token) {
+	const node = module.exports.nodes[token];
+
+	if (pollInterval[token][multiChannel][capability]) {
+		clearInterval(pollInterval[token][multiChannel][capability]);
+		pollInterval[token][multiChannel][capability] = null
+	}
+
+	if (value === 0) return;
+
+	switch (capability) {
+		case 'onoff': {
+			if (typeof node.instance.MultiChannelNodes[multiChannel].CommandClass.COMMAND_CLASS_SWITCH_BINARY !== "undefined") {
+				pollInterval[token][multiChannel].onoff = setInterval(() => {
+					module.exports._debug('polling: [' + multiChannel + '].' + capability);
+					node.instance.MultiChannelNodes[multiChannel].CommandClass.COMMAND_CLASS_SWITCH_BINARY.SWITCH_BINARY_GET({});
+				}, value * 1000);
+			}
+		} break;
+
+		case 'measure': {
+			if (typeof node.instance.MultiChannelNodes[multiChannel].CommandClass.COMMAND_CLASS_METER !== "undefined") {
+				pollInterval[token][multiChannel].measure = setInterval(() => {
+					module.exports._debug('polling: [' + multiChannel + '].' + capability);
+					node.instance.MultiChannelNodes[multiChannel].CommandClass.COMMAND_CLASS_METER.METER_GET({
+						Properties1: {
+							Scale: 2,
+						},
+					});
+				}, value * 1000);
+			}
+		} break;
+
+		case 'meter': {
+			if (typeof node.instance.MultiChannelNodes[multiChannel].CommandClass.COMMAND_CLASS_METER !== "undefined") {
+				pollInterval[token][multiChannel].meter = setInterval(() => {
+					module.exports._debug('polling: [' + multiChannel + '].' + capability);
+					node.instance.MultiChannelNodes[multiChannel].CommandClass.COMMAND_CLASS_METER.METER_GET({
+						Properties1: {
+							Scale: 0,
+						},
+					});
+				}, value * 1000);
+			}
+		} break;
+	}
+}

--- a/drivers/powernode-6/driver.js
+++ b/drivers/powernode-6/driver.js
@@ -11,7 +11,6 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 		onoff: {
 			command_class: 'COMMAND_CLASS_SWITCH_BINARY',
 			command_get: 'SWITCH_BINARY_GET',
-			command_get_cb: false,
 			command_set: 'SWITCH_BINARY_SET',
 			command_set_parser: value => ({
 				'Switch Value': value,
@@ -32,7 +31,9 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 			}),
 			command_report: 'METER_REPORT',
 			command_report_parser: report => {
-				if (typeof report.Properties2.Scale !== 'undefined' &&
+				if (report &&
+					report.hasOwnProperty('Properties2') &&
+					report.Properties2.hasOwnProperty('Scale') &&
 					report.Properties2.Scale === 2) {
 					return report['Meter Value (Parsed)'];
 				}
@@ -52,7 +53,9 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 			}),
 			command_report: 'METER_REPORT',
 			command_report_parser: report => {
-				if (typeof report.Properties2.Scale !== 'undefined' &&
+				if (report &&
+					report.hasOwnProperty('Properties2') &&
+					report.Properties2.hasOwnProperty('Scale') &&
 					report.Properties2.Scale === 0) {
 					return report['Meter Value (Parsed)'];
 				}
@@ -70,7 +73,7 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 
 				if (settings.zw_node_id.indexOf('.') < 0 && !endpointInterval.hasOwnProperty(token)) {
 					endpointInterval[token] = {};
-					for(var i = 1; i <= 6; i++) {
+					for (var i = 1; i <= 6; i++) {
 						endpointInterval[token][i] = [];
 						if (settings['endpoint_interval_onoff_' + i]) setEndpointInterval('onoff', i, settings['endpoint_interval_onoff_' + i], token);
 						if (settings['endpoint_interval_measure_' + i]) setEndpointInterval('measure', i, settings['endpoint_interval_measure_' + i], token);
@@ -127,7 +130,7 @@ Homey.manager('flow').on('action.PN6_reset_meter', (callback, args) => {
 	} else return callback('unknown_error');
 });
 
-function setEndpointInterval (capability, multiChannel, value, token) {
+function setEndpointInterval(capability, multiChannel, value, token) {
 	const node = module.exports.nodes[token];
 
 	if (endpointInterval[token][multiChannel][capability]) {
@@ -138,39 +141,45 @@ function setEndpointInterval (capability, multiChannel, value, token) {
 	if (value === 0) return;
 
 	switch (capability) {
-		case 'onoff': {
-			if (typeof node.instance.MultiChannelNodes[multiChannel].CommandClass.COMMAND_CLASS_SWITCH_BINARY !== "undefined") {
-				endpointInterval[token][multiChannel].onoff = setInterval(() => {
-					module.exports._debug('polling: MultiChannelNode[' + multiChannel + '].' + capability);
-					node.instance.MultiChannelNodes[multiChannel].CommandClass.COMMAND_CLASS_SWITCH_BINARY.SWITCH_BINARY_GET({});
-				}, value * 1000);
+		case 'onoff':
+			{
+				if (typeof node.instance.MultiChannelNodes[multiChannel].CommandClass.COMMAND_CLASS_SWITCH_BINARY !== "undefined") {
+					endpointInterval[token][multiChannel].onoff = setInterval(() => {
+						module.exports._debug('polling: MultiChannelNode[' + multiChannel + '].' + capability);
+						node.instance.MultiChannelNodes[multiChannel].CommandClass.COMMAND_CLASS_SWITCH_BINARY.SWITCH_BINARY_GET({});
+					}, value * 1000);
+				}
 			}
-		} break;
+			break;
 
-		case 'measure': {
-			if (typeof node.instance.MultiChannelNodes[multiChannel].CommandClass.COMMAND_CLASS_METER !== "undefined") {
-				endpointInterval[token][multiChannel].measure = setInterval(() => {
-					module.exports._debug('polling: MultiChannelNode[' + multiChannel + '].' + capability);
-					node.instance.MultiChannelNodes[multiChannel].CommandClass.COMMAND_CLASS_METER.METER_GET({
-						Properties1: {
-							Scale: 2,
-						},
-					});
-				}, value * 1000);
+		case 'measure':
+			{
+				if (typeof node.instance.MultiChannelNodes[multiChannel].CommandClass.COMMAND_CLASS_METER !== "undefined") {
+					endpointInterval[token][multiChannel].measure = setInterval(() => {
+						module.exports._debug('polling: MultiChannelNode[' + multiChannel + '].' + capability);
+						node.instance.MultiChannelNodes[multiChannel].CommandClass.COMMAND_CLASS_METER.METER_GET({
+							Properties1: {
+								Scale: 2,
+							},
+						});
+					}, value * 1000);
+				}
 			}
-		} break;
+			break;
 
-		case 'meter': {
-			if (typeof node.instance.MultiChannelNodes[multiChannel].CommandClass.COMMAND_CLASS_METER !== "undefined") {
-				endpointInterval[token][multiChannel].meter = setInterval(() => {
-					module.exports._debug('polling: MultiChannelNode[' + multiChannel + '].' + capability);
-					node.instance.MultiChannelNodes[multiChannel].CommandClass.COMMAND_CLASS_METER.METER_GET({
-						Properties1: {
-							Scale: 0,
-						},
-					});
-				}, value * 1000);
+		case 'meter':
+			{
+				if (typeof node.instance.MultiChannelNodes[multiChannel].CommandClass.COMMAND_CLASS_METER !== "undefined") {
+					endpointInterval[token][multiChannel].meter = setInterval(() => {
+						module.exports._debug('polling: MultiChannelNode[' + multiChannel + '].' + capability);
+						node.instance.MultiChannelNodes[multiChannel].CommandClass.COMMAND_CLASS_METER.METER_GET({
+							Properties1: {
+								Scale: 0,
+							},
+						});
+					}, value * 1000);
+				}
 			}
-		} break;
+			break;
 	}
 }

--- a/drivers/powernode-6/driver.js
+++ b/drivers/powernode-6/driver.js
@@ -102,7 +102,7 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 		endpoint_interval_meter_1: (newValue, oldValue, deviceData) => setEndpointInterval('meter', 1, newValue, deviceData.token),
 		endpoint_interval_onoff_2: (newValue, oldValue, deviceData) => setEndpointInterval('onoff', 2, newValue, deviceData.token),
 		endpoint_interval_measure_2: (newValue, oldValue, deviceData) => setEndpointInterval('measure', 2, newValue, deviceData.token),
-		endpoint_interval_meter_2: (newValue, oldValue, deviceData) => setEndpointInterval('meter', 1, newValue, deviceData.token),
+		endpoint_interval_meter_2: (newValue, oldValue, deviceData) => setEndpointInterval('meter', 2, newValue, deviceData.token),
 		endpoint_interval_onoff_3: (newValue, oldValue, deviceData) => setEndpointInterval('onoff', 3, newValue, deviceData.token),
 		endpoint_interval_measure_3: (newValue, oldValue, deviceData) => setEndpointInterval('measure', 3, newValue, deviceData.token),
 		endpoint_interval_meter_3: (newValue, oldValue, deviceData) => setEndpointInterval('meter', 3, newValue, deviceData.token),
@@ -135,7 +135,7 @@ function setEndpointInterval(capability, multiChannel, value, token) {
 
 	if (endpointInterval[token][multiChannel][capability]) {
 		clearInterval(endpointInterval[token][multiChannel][capability]);
-		endpointInterval[token][multiChannel][capability] = null
+		endpointInterval[token][multiChannel][capability] = null;
 	}
 
 	if (value === 0) return;

--- a/drivers/powernode-6/driver.js
+++ b/drivers/powernode-6/driver.js
@@ -18,6 +18,7 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 			}),
 			command_report: 'SWITCH_BINARY_REPORT',
 			command_report_parser: report => report.Value === 'on/enable',
+			pollInterval: 'poll_interval_onoff',
 		},
 
 		measure_power: {
@@ -31,13 +32,13 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 			}),
 			command_report: 'METER_REPORT',
 			command_report_parser: report => {
-				if (report.hasOwnProperty('Properties2') &&
-					report.Properties2.hasOwnProperty('Scale') &&
+				if (typeof report.Properties2.Scale !== 'undefined' &&
 					report.Properties2.Scale === 2) {
 					return report['Meter Value (Parsed)'];
 				}
 				return null;
 			},
+			pollInterval: 'poll_interval_meter',
 		},
 
 		meter_power: {
@@ -51,13 +52,13 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 			}),
 			command_report: 'METER_REPORT',
 			command_report_parser: report => {
-				if (report.hasOwnProperty('Properties2') &&
-					report.Properties2.hasOwnProperty('Scale') &&
+				if (typeof report.Properties2.Scale !== 'undefined' &&
 					report.Properties2.Scale === 0) {
 					return report['Meter Value (Parsed)'];
 				}
 				return null;
 			},
+			pollInterval: 'poll_interval_measure',
 		},
 	},
 

--- a/drivers/powernode-6/driver.js
+++ b/drivers/powernode-6/driver.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const ZwaveDriver = require('homey-zwavedriver');
-const pollInterval = {};
+const endpointInterval = {};
 
 // http://www.pepper1.net/zwavedb/device/280
 
@@ -67,13 +67,13 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 			module.exports.getSettings(node.device_data, (err, settings) => {
 				if (err) return console.error('error retrieving settings for device', err);
 
-				if (settings.zw_node_id.indexOf('.') < 0 && !pollInterval.hasOwnProperty(token)) {
-					pollInterval[token] = {};
+				if (settings.zw_node_id.indexOf('.') < 0 && !endpointInterval.hasOwnProperty(token)) {
+					endpointInterval[token] = {};
 					for(var i = 1; i <= 6; i++) {
-						pollInterval[token][i] = [];
-						if (settings['poll_onoff_' + i]) setMultiInterval('onoff', i, settings['poll_onoff_' + i], token);
-						if (settings['poll_measure_' + i]) setMultiInterval('measure', i, settings['poll_measure_' + i], token);
-						if (settings['poll_meter_' + i]) setMultiInterval('meter', i, settings['poll_meter_' + i], token);
+						endpointInterval[token][i] = [];
+						if (settings['endpoint_interval_onoff_' + i]) setEndpointInterval('onoff', i, settings['endpoint_interval_onoff_' + i], token);
+						if (settings['endpoint_interval_measure_' + i]) setEndpointInterval('measure', i, settings['endpoint_interval_measure_' + i], token);
+						if (settings['endpoint_interval_meter_' + i]) setEndpointInterval('meter', i, settings['endpoint_interval_meter_' + i], token);
 					}
 				}
 			});
@@ -93,33 +93,31 @@ module.exports = new ZwaveDriver(path.basename(__dirname), {
 			size: 1,
 			signed: false,
 		},
-		poll_onoff_1: (newValue, oldValue, deviceData) => setMultiInterval('onoff', 1, newValue, deviceData.token),
-		poll_measure_1: (newValue, oldValue, deviceData) => setMultiInterval('measure', 1, newValue, deviceData.token),
-		poll_meter_1: (newValue, oldValue, deviceData) => setMultiInterval('meter', 1, newValue, deviceData.token),
-		poll_onoff_2: (newValue, oldValue, deviceData) => setMultiInterval('onoff', 2, newValue, deviceData.token),
-		poll_measure_2: (newValue, oldValue, deviceData) => setMultiInterval('measure', 2, newValue, deviceData.token),
-		poll_meter_2: (newValue, oldValue, deviceData) => setMultiInterval('meter', 1, newValue, deviceData.token),
-		poll_onoff_3: (newValue, oldValue, deviceData) => setMultiInterval('onoff', 3, newValue, deviceData.token),
-		poll_measure_3: (newValue, oldValue, deviceData) => setMultiInterval('measure', 3, newValue, deviceData.token),
-		poll_meter_3: (newValue, oldValue, deviceData) => setMultiInterval('meter', 3, newValue, deviceData.token),
-		poll_onoff_4: (newValue, oldValue, deviceData) => setMultiInterval('onoff', 4, newValue, deviceData.token),
-		poll_measure_4: (newValue, oldValue, deviceData) => setMultiInterval('measure', 4, newValue, deviceData.token),
-		poll_meter_4: (newValue, oldValue, deviceData) => setMultiInterval('meter', 4, newValue, deviceData.token),
-		poll_onoff_5: (newValue, oldValue, deviceData) => setMultiInterval('onoff', 5, newValue, deviceData.token),
-		poll_measure_5: (newValue, oldValue, deviceData) => setMultiInterval('measure', 5, newValue, deviceData.token),
-		poll_meter_5: (newValue, oldValue, deviceData) => setMultiInterval('meter', 5, newValue, deviceData.token),
-		poll_onoff_6: (newValue, oldValue, deviceData) => setMultiInterval('onoff', 6, newValue, deviceData.token),
-		poll_measure_6: (newValue, oldValue, deviceData) => setMultiInterval('measure', 6, newValue, deviceData.token),
-		poll_meter_6: (newValue, oldValue, deviceData) => setMultiInterval('meter', 6, newValue, deviceData.token),
+		endpoint_interval_onoff_1: (newValue, oldValue, deviceData) => setEndpointInterval('onoff', 1, newValue, deviceData.token),
+		endpoint_interval_measure_1: (newValue, oldValue, deviceData) => setEndpointInterval('measure', 1, newValue, deviceData.token),
+		endpoint_interval_meter_1: (newValue, oldValue, deviceData) => setEndpointInterval('meter', 1, newValue, deviceData.token),
+		endpoint_interval_onoff_2: (newValue, oldValue, deviceData) => setEndpointInterval('onoff', 2, newValue, deviceData.token),
+		endpoint_interval_measure_2: (newValue, oldValue, deviceData) => setEndpointInterval('measure', 2, newValue, deviceData.token),
+		endpoint_interval_meter_2: (newValue, oldValue, deviceData) => setEndpointInterval('meter', 1, newValue, deviceData.token),
+		endpoint_interval_onoff_3: (newValue, oldValue, deviceData) => setEndpointInterval('onoff', 3, newValue, deviceData.token),
+		endpoint_interval_measure_3: (newValue, oldValue, deviceData) => setEndpointInterval('measure', 3, newValue, deviceData.token),
+		endpoint_interval_meter_3: (newValue, oldValue, deviceData) => setEndpointInterval('meter', 3, newValue, deviceData.token),
+		endpoint_interval_onoff_4: (newValue, oldValue, deviceData) => setEndpointInterval('onoff', 4, newValue, deviceData.token),
+		endpoint_interval_measure_4: (newValue, oldValue, deviceData) => setEndpointInterval('measure', 4, newValue, deviceData.token),
+		endpoint_interval_meter_4: (newValue, oldValue, deviceData) => setEndpointInterval('meter', 4, newValue, deviceData.token),
+		endpoint_interval_onoff_5: (newValue, oldValue, deviceData) => setEndpointInterval('onoff', 5, newValue, deviceData.token),
+		endpoint_interval_measure_5: (newValue, oldValue, deviceData) => setEndpointInterval('measure', 5, newValue, deviceData.token),
+		endpoint_interval_meter_5: (newValue, oldValue, deviceData) => setEndpointInterval('meter', 5, newValue, deviceData.token),
+		endpoint_interval_onoff_6: (newValue, oldValue, deviceData) => setEndpointInterval('onoff', 6, newValue, deviceData.token),
+		endpoint_interval_measure_6: (newValue, oldValue, deviceData) => setEndpointInterval('measure', 6, newValue, deviceData.token),
+		endpoint_interval_meter_6: (newValue, oldValue, deviceData) => setEndpointInterval('meter', 6, newValue, deviceData.token),
 	},
 });
 
 Homey.manager('flow').on('action.PN6_reset_meter', (callback, args) => {
 	const node = module.exports.nodes[args.device.token];
-	if (node &&
-		node.instance &&
-		node.instance.CommandClass &&
-		node.instance.CommandClass.COMMAND_CLASS_METER) {
+
+	if (typeof node.instance.CommandClass.COMMAND_CLASS_METER !== 'undefined') {
 		node.instance.CommandClass.COMMAND_CLASS_METER.METER_RESET({}, (err, result) => {
 			if (err) return callback(err);
 			if (result === 'TRANSMIT_COMPLETE_OK') return callback(null, true);
@@ -128,12 +126,12 @@ Homey.manager('flow').on('action.PN6_reset_meter', (callback, args) => {
 	} else return callback('unknown_error');
 });
 
-function setMultiInterval (capability, multiChannel, value, token) {
+function setEndpointInterval (capability, multiChannel, value, token) {
 	const node = module.exports.nodes[token];
 
-	if (pollInterval[token][multiChannel][capability]) {
-		clearInterval(pollInterval[token][multiChannel][capability]);
-		pollInterval[token][multiChannel][capability] = null
+	if (endpointInterval[token][multiChannel][capability]) {
+		clearInterval(endpointInterval[token][multiChannel][capability]);
+		endpointInterval[token][multiChannel][capability] = null
 	}
 
 	if (value === 0) return;
@@ -141,8 +139,8 @@ function setMultiInterval (capability, multiChannel, value, token) {
 	switch (capability) {
 		case 'onoff': {
 			if (typeof node.instance.MultiChannelNodes[multiChannel].CommandClass.COMMAND_CLASS_SWITCH_BINARY !== "undefined") {
-				pollInterval[token][multiChannel].onoff = setInterval(() => {
-					module.exports._debug('polling: [' + multiChannel + '].' + capability);
+				endpointInterval[token][multiChannel].onoff = setInterval(() => {
+					module.exports._debug('polling: MultiChannelNode[' + multiChannel + '].' + capability);
 					node.instance.MultiChannelNodes[multiChannel].CommandClass.COMMAND_CLASS_SWITCH_BINARY.SWITCH_BINARY_GET({});
 				}, value * 1000);
 			}
@@ -150,8 +148,8 @@ function setMultiInterval (capability, multiChannel, value, token) {
 
 		case 'measure': {
 			if (typeof node.instance.MultiChannelNodes[multiChannel].CommandClass.COMMAND_CLASS_METER !== "undefined") {
-				pollInterval[token][multiChannel].measure = setInterval(() => {
-					module.exports._debug('polling: [' + multiChannel + '].' + capability);
+				endpointInterval[token][multiChannel].measure = setInterval(() => {
+					module.exports._debug('polling: MultiChannelNode[' + multiChannel + '].' + capability);
 					node.instance.MultiChannelNodes[multiChannel].CommandClass.COMMAND_CLASS_METER.METER_GET({
 						Properties1: {
 							Scale: 2,
@@ -163,8 +161,8 @@ function setMultiInterval (capability, multiChannel, value, token) {
 
 		case 'meter': {
 			if (typeof node.instance.MultiChannelNodes[multiChannel].CommandClass.COMMAND_CLASS_METER !== "undefined") {
-				pollInterval[token][multiChannel].meter = setInterval(() => {
-					module.exports._debug('polling: [' + multiChannel + '].' + capability);
+				endpointInterval[token][multiChannel].meter = setInterval(() => {
+					module.exports._debug('polling: MultiChannelNode[' + multiChannel + '].' + capability);
 					node.instance.MultiChannelNodes[multiChannel].CommandClass.COMMAND_CLASS_METER.METER_GET({
 						Properties1: {
 							Scale: 0,


### PR DESCRIPTION
This will add split polling of the node 6 into each socket separate.
also includes a 5 second difference between each socket to split out the reports.

polling on on/off capability is 0 because this is only needed if the status changes from external sources.
since this is not possible inside homey yet anyway, and save as much traffic as possible it is turned off.

callback was turned on for binary switch, to get initial report on the state

also fixes issue #22

created in collaboration with:
@TedTolboom (also tester)
@jghaanstra (tester)